### PR TITLE
Fix issue where warmup would exit when there was an error.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,13 +45,13 @@ func CreateConfig() {
 		log.Printf("reading configs from file: %v", cfgFile)
 		file, err := os.Open(cfgFile)
 		if err != nil {
-			log.Fatal("can't open config file: ", err)
+			log.Print("can't open config file: ", err)
 		}
 		defer file.Close()
 		decoder := json.NewDecoder(file)
 		err = decoder.Decode(&opts)
 		if err != nil {
-			log.Fatal("can't decode config JSON: ", err)
+			log.Print("can't decode config JSON: ", err)
 		}
 	}
 	flag.Parse()
@@ -66,12 +66,12 @@ func RunCmdRoot() {
 		// CPU profile
 		f, err := os.Create(opts.Profile.CPU)
 		if err != nil {
-			log.Fatalf("could not create CPU profile: %v", err)
+			log.Printf("could not create CPU profile: %v", err)
 		}
 		defer f.Close()
 
 		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Fatalf("could not start CPU profile: %v", err)
+			log.Printf("could not start CPU profile: %v", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
@@ -103,31 +103,31 @@ func RunCmdRoot() {
 		done,
 	)
 
-	if err != nil {
-		log.Fatalf("new warmup: %v", err)
-	}
+	if err == nil {
+		log.Printf("new warmup: %v", err)
 
-	httpOptions := opts.GetWarmupHttpHeaders()
-	httpRequests, err := opts.GetWarmupHttpRequests(done)
-	if err != nil {
-		log.Fatalf("http options: %v", err)
-	}
-
-	grpcOptions := opts.GetWarmupGrpcHeaders()
-	grpcRequests, err := opts.GetWarmupGrpcRequests(done)
-	if err != nil {
-		log.Fatalf("grpc options: %v", err)
-	}
-
-	httpResponse := wp.HttpWarmup(httpOptions, httpRequests)
-	grpcResponse := wp.GrpcWarmup(grpcOptions, grpcRequests)
-
-	response := merge(httpResponse, grpcResponse)
-	for r := range response {
-		if r.Error != nil {
-			log.Printf("%s response %d milliseconds: error: %v", r.Type, r.Duration/time.Millisecond, r.Error)
+		httpOptions := opts.GetWarmupHttpHeaders()
+		httpRequests, err := opts.GetWarmupHttpRequests(done)
+		if err != nil {
+			log.Printf("http options: %v", err)
 		}
-		log.Printf("%s response %d milliseconds: OK", r.Type, r.Duration/time.Millisecond)
+
+		grpcOptions := opts.GetWarmupGrpcHeaders()
+		grpcRequests, err := opts.GetWarmupGrpcRequests(done)
+		if err != nil {
+			log.Printf("grpc options: %v", err)
+		}
+
+		httpResponse := wp.HttpWarmup(httpOptions, httpRequests)
+		grpcResponse := wp.GrpcWarmup(grpcOptions, grpcRequests)
+
+		response := merge(httpResponse, grpcResponse)
+		for r := range response {
+			if r.Error != nil {
+				log.Printf("%s response %d milliseconds: error: %v", r.Type, r.Duration/time.Millisecond, r.Error)
+			}
+			log.Printf("%s response %d milliseconds: OK", r.Type, r.Duration/time.Millisecond)
+		}
 	}
 
 	if opts.ServerProbe.Enabled {
@@ -156,13 +156,13 @@ func RunCmdRoot() {
 		log.Printf("memory profile will be written to %s file", opts.Profile.Memory)
 		f, err := os.Create(opts.Profile.Memory)
 		if err != nil {
-			log.Fatalf("could not create memory profile: %v", err)
+			log.Printf("could not create memory profile: %v", err)
 		}
 		defer f.Close()
 
 		runtime.GC() // get up-to-date statistics
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			log.Fatalf("could not write memory profile: %v", err)
+			log.Printf("could not write memory profile: %v", err)
 		}
 	}
 }

--- a/pkg/warmup/target.go
+++ b/pkg/warmup/target.go
@@ -52,10 +52,11 @@ func NewTarget(readinessHttpClient whttp.Client, httpClient whttp.Client, grpcCl
 		options:             options,
 	}
 
-	if err := t.waitForReadinessProbe(done); err != nil {
+	err := t.waitForReadinessProbe(done)
+	if err != nil {
 		return Target{}, fmt.Errorf("wait for rediness probe: %v", err)
 	}
-	return t, nil
+	return t, err
 }
 
 func (t Target) waitForReadinessProbe(done <-chan struct{}) error {
@@ -66,7 +67,7 @@ func (t Target) waitForReadinessProbe(done <-chan struct{}) error {
 	for {
 		select {
 		case <-timeout:
-			return fmt.Errorf("target readiness proble: timeout %d seconds exceeded", t.options.ReadinessTimeoutInSeconds)
+			return fmt.Errorf("target readiness probe: timeout %d seconds exceeded", t.options.ReadinessTimeoutInSeconds)
 		case <-done:
 			return errors.New("target readiness probe: received done signal")
 		default:

--- a/pkg/warmup/warmup.go
+++ b/pkg/warmup/warmup.go
@@ -56,7 +56,7 @@ func NewWarmup(readinessHttpClient http.Client, httpClient http.Client, grpcClie
 	if err != nil {
 		return Warmup{}, fmt.Errorf("new target: %v", err)
 	}
-	return Warmup{target: target, options: options}, nil
+	return Warmup{target: target, options: options}, err
 }
 
 func (w Warmup) HttpWarmup(headers map[string]string, requests <-chan HttpRequest) <-chan Response {


### PR DESCRIPTION
### :pencil: Description
This change fixes a couple of issues that would result to warmup exit / non-successful termination in case of errors.
`log.Fatal` should never be called since this would kill the container which in its turn would cause pod restarts if running in K8S.

Also, errors when running the warmup vs the target readiness url were not propagated all the way up to the main method. This meant that warmup would continue its work (i.e. sending requests).

### :link: Related Issues