### PR TITLE
Support for placeholders for dates

### DIFF
--- a/cmd/flags/target.go
+++ b/cmd/flags/target.go
@@ -23,14 +23,14 @@ import (
 )
 
 type Target struct {
-	HttpHost               string `json:"target-http-host"`
-	HttpPort               int    `json:"target-http-port"`
-	GrpcHost               string `json:"target-grpc-host"`
-	GrpcPort               int    `json:"target-grpc-port"`
-	ReadinessPath          string `json:"target-readiness-path"`
-	ReadinessPort          int    `json:"target-readiness-port"`
-	ReadinessTimoutSeconds int    `json:"target-readiness-timeout-seconds"`
-	Insecure               bool   `json:"target-insecure"`
+	HttpHost                string `json:"target-http-host"`
+	HttpPort                int    `json:"target-http-port"`
+	GrpcHost                string `json:"target-grpc-host"`
+	GrpcPort                int    `json:"target-grpc-port"`
+	ReadinessPath           string `json:"target-readiness-path"`
+	ReadinessPort           int    `json:"target-readiness-port"`
+	ReadinessTimeoutSeconds int    `json:"target-readiness-timeout-seconds"`
+	Insecure                bool   `json:"target-insecure"`
 }
 
 func (t *Target) String() string {
@@ -44,7 +44,7 @@ func (t *Target) InitFlags() {
 	flag.IntVar(&t.GrpcPort, "target-grpc-port", 50051, "Grpc port for warm up requests")
 	flag.StringVar(&t.ReadinessPath, "target-readiness-path", "/ready", "The path used for target readiness probe")
 	flag.IntVar(&t.ReadinessPort, "target-readiness-port", toIntOrDefaultIfNull(&t.HttpPort, 8080), "The port used for target readiness probe")
-	flag.IntVar(&t.ReadinessTimoutSeconds, "target-readiness-timeout-seconds", -1, "Timeout for target readiness probe")
+	flag.IntVar(&t.ReadinessTimeoutSeconds, "target-readiness-timeout-seconds", -1, "Timeout for target readiness probe")
 	flag.BoolVar(&t.Insecure, "target-insecure", false, "Whether to skip TLS validation")
 }
 
@@ -61,7 +61,7 @@ func (t *Target) GetWarmupTargetOptions() warmup.TargetOptions {
 	return warmup.TargetOptions{
 		ReadinessPath:             t.ReadinessPath,
 		ReadinessPort:             t.ReadinessPort,
-		ReadinessTimeoutInSeconds: t.ReadinessTimoutSeconds,
+		ReadinessTimeoutInSeconds: t.ReadinessTimeoutSeconds,
 	}
 }
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -57,6 +57,15 @@ E.g.:
 gRPC requests are in the form `service/method[:message]` (`message` is optional). Host and port are taken from `target-grpc-host` and
 `target-grpc-port` flags.
 
+#### Placeholders for dates
+
+Mittens allows you to use the keywords `{today}` and `{tomorrow}` when you need to use valid dates in your requests in the following format: YYYY-MM-DD.
+These placeholders can be used in both the urls and the body.
+You can also use modifiers with `{today}` to adjust to a specific offset, for example `{today+2}` to represent 2 days from now.
+
+E.g.:
+ - `post:/foo:{"date": "{today}"}`
+
 ### Liveness/readiness probes
 
 #### File probes

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -47,11 +47,11 @@ func NewClient(host string, insecure bool) Client {
 }
 
 // Send http request and returns error also if response code is NOT 2XX
-func (c Client) Request(method, path string, headers map[string]string, requestBody []byte) error {
+func (c Client) Request(method, path string, headers map[string]string, requestBody *string) error {
 
 	var body io.Reader
-	if len(requestBody) != 0 {
-		body = bytes.NewBuffer(requestBody)
+	if requestBody != nil {
+		body = bytes.NewBuffer([]byte(*requestBody))
 	}
 
 	url := fmt.Sprintf("%s/%s", strings.TrimRight(c.host, "/"), strings.TrimLeft(path, "/"))

--- a/pkg/warmup/target.go
+++ b/pkg/warmup/target.go
@@ -53,7 +53,7 @@ func NewTarget(readinessHttpClient whttp.Client, httpClient whttp.Client, grpcCl
 	}
 
 	if err := t.waitForReadinessProbe(done); err != nil {
-		return Target{}, fmt.Errorf("wait for rediness probe: %v", err)
+		return Target{}, fmt.Errorf("wait for readiness probe: %v", err)
 	}
 	return t, nil
 }

--- a/pkg/warmup/target.go
+++ b/pkg/warmup/target.go
@@ -60,10 +60,12 @@ func NewTarget(readinessHttpClient whttp.Client, httpClient whttp.Client, grpcCl
 
 func (t Target) waitForReadinessProbe(done <-chan struct{}) error {
 
-	log.Printf("waiting for %d:%s target readiness probe", t.options.ReadinessPort, t.options.ReadinessPath)
+	log.Printf("waiting for %d:%s target readiness probe for %ds", t.options.ReadinessPort, t.options.ReadinessPath, t.options.ReadinessTimeoutInSeconds)
+
+	timeout := time.After(time.Duration(t.options.ReadinessTimeoutInSeconds) * time.Second)
 	for {
 		select {
-		case <-time.After(time.Duration(t.options.ReadinessTimeoutInSeconds) * time.Second):
+		case <-timeout:
 			return fmt.Errorf("target readiness proble: timeout %d seconds exceeded", t.options.ReadinessTimeoutInSeconds)
 		case <-done:
 			return errors.New("target readiness probe: received done signal")

--- a/pkg/warmup/warmup.go
+++ b/pkg/warmup/warmup.go
@@ -36,7 +36,7 @@ type GrpcRequest struct {
 type HttpRequest struct {
 	Method string
 	Path   string
-	Body   []byte
+	Body   *string
 }
 
 type Warmup struct {


### PR DESCRIPTION
### :pencil: Description
Support for placeholders for dates. Can be used in the url or body of a request.

Example:
- `post:/foo:{"date": "{today}"}`
