### PR TITLE
Trigger Actions on pull_request event to include PRs from forks.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,10 @@
 name: Build
-on: [push]
+
+on:
+  pull_request:
+    branches:
+      - master
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
### :pencil: Description
Currently when someone raises a PR from a fork GitHub Actions are not triggered.
This is due to the fact that we rely on the `push` event which is only sent for the base repo.

For PR from forks to trigger Actions we need to use the [pull_request](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories) event.

### :link: Related Issues