### PR TITLE
Add Algolia search.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -60,6 +60,11 @@ const siteConfig = {
     theme: 'github',
   },
 
+  algolia: {
+    apiKey: 'b384c10816b317ab3062e38860f2e98b',
+    indexName: 'expediagroup_mittens',
+  },
+
   // Add custom scripts here that would be placed in <script> tags.
   scripts: ['https://buttons.github.io/buttons.js'],
 


### PR DESCRIPTION
### :pencil: Description
Adds search to docs using Algolia.
This is the suggested way to enable search in [Docusaurus](https://docusaurus.io/docs/en/search) docs.
Algolia is a free service which crawls the docs every 24 hours.

### :link: Related Issues