### PR TITLE
[#28] Add support for gRPC health checks

### DIFF
--- a/cmd/flags/grpc.go
+++ b/cmd/flags/grpc.go
@@ -18,8 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"mittens/pkg/warmup"
-	"strings"
+	"mittens/pkg/grpc"
 )
 
 type Grpc struct {
@@ -40,37 +39,20 @@ func (g *Grpc) GetWarmupGrpcHeaders() []string {
 	return g.Headers
 }
 
-func (g *Grpc) GetWarmupGrpcRequests() ([]warmup.GrpcRequest, error) {
+func (g *Grpc) GetWarmupGrpcRequests() ([]grpc.Request, error) {
 	log.Print(g.Requests)
 	return toGrpcRequests(g.Requests)
 }
 
-func toGrpcRequests(requestsFlag []string) ([]warmup.GrpcRequest, error) {
+func toGrpcRequests(requestsFlag []string) ([]grpc.Request, error) {
 
-	var requests []warmup.GrpcRequest
+	var requests []grpc.Request
 	for _, requestFlag := range requestsFlag {
-		log.Print(requestsFlag)
-		request, err := toGrpcRequest(requestFlag)
+		request, err := grpc.ToGrpcRequest(requestFlag)
 		if err != nil {
 			return nil, err
 		}
 		requests = append(requests, request)
 	}
 	return requests, nil
-}
-
-func toGrpcRequest(requestFlag string) (warmup.GrpcRequest, error) {
-
-	// service/method[:message]
-	parts := strings.SplitN(requestFlag, ":", 2)
-	log.Print(parts)
-	if len(strings.Split(parts[0], "/")) != 2 {
-		return warmup.GrpcRequest{}, fmt.Errorf("invalid request flag: %s, expected format <service>/<method>[:body]", requestFlag)
-	}
-
-	request := warmup.GrpcRequest{ServiceMethod: parts[0]}
-	if len(parts) == 2 {
-		request.Message = []byte(parts[1])
-	}
-	return request, nil
 }

--- a/cmd/flags/grpc_test.go
+++ b/cmd/flags/grpc_test.go
@@ -34,30 +34,3 @@ func TestGrpc_ToGrpcRequests(t *testing.T) {
 	assert.Equal(t, "svc1/ping", requests[0].ServiceMethod)
 	assert.Equal(t, "svc2/ping", requests[1].ServiceMethod)
 }
-
-func TestGrpc_FlagToGrpcRequest(t *testing.T) {
-
-	requestFlag := `health/ping:{"db": "true"}`
-	request, err := toGrpcRequest(requestFlag)
-	require.NoError(t, err)
-
-	assert.Equal(t, "health/ping", request.ServiceMethod)
-	assert.Equal(t, `{"db": "true"}`, string(request.Message))
-}
-
-func TestGrpc_FlagWithoutBodyToGrpcRequest(t *testing.T) {
-
-	requestFlag := `health/ping`
-	request, err := toGrpcRequest(requestFlag)
-	require.NoError(t, err)
-
-	assert.Equal(t, "health/ping", request.ServiceMethod)
-	assert.Nil(t, request.Message)
-}
-
-func TestGrpc_InvalidFlagToGrpcRequest(t *testing.T) {
-
-	requestFlag := `health:ping`
-	_, err := toGrpcRequest(requestFlag)
-	require.Error(t, err)
-}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -45,7 +45,7 @@ func TestWarmupSidecarWithFileProbe(t *testing.T) {
 		"-http-requests=get:/delay",
 		"-concurrency=4",
 		"-exit-after-warmup=true",
-		"-target-readiness-path=/",
+		"-target-readiness-http-path=/",
 		"-timeout-seconds=5"}
 
 	CreateConfig()
@@ -67,7 +67,7 @@ func TestWarmupSidecarWithServerProbe(t *testing.T) {
 		"-http-requests=get:/delay",
 		"-concurrency=4",
 		"-exit-after-warmup=true",
-		"-target-readiness-path=/",
+		"-target-readiness-http-path=/",
 		"-timeout-seconds=5"}
 
 	CreateConfig()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -56,7 +56,7 @@ func TestWarmupSidecarWithFileProbe(t *testing.T) {
 	assert.Contains(t, opts.Http.Requests, "get:/delay")
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
-	assert.Equal(t, "/", opts.Target.ReadinessPath)
+	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
 	assert.Equal(t, 5, opts.TimeoutSeconds)
 }
 
@@ -78,7 +78,7 @@ func TestWarmupSidecarWithServerProbe(t *testing.T) {
 	assert.Contains(t, opts.Http.Requests, "get:/delay")
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
-	assert.Equal(t, "/", opts.Target.ReadinessPath)
+	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
 	assert.Equal(t, 5, opts.TimeoutSeconds)
 }
 
@@ -94,7 +94,7 @@ func TestConfigsFromFile(t *testing.T) {
 	assert.Contains(t, opts.Http.Requests, "get:/delay")
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
-	assert.Equal(t, "/", opts.Target.ReadinessPath)
+	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
 	assert.Equal(t, 5, opts.TimeoutSeconds)
 }
 

--- a/cmd/sample_configs.json
+++ b/cmd/sample_configs.json
@@ -2,7 +2,7 @@
   "exit-after-warmup": true,
   "timeout-seconds": 5,
   "concurrency": 4,
-  "target-readiness-path": "/",
+  "target-readiness-http-path": "/",
   "file-probe-enabled": true,
   "server-probe-enabled": true,
   "http-requests": ["get:/delay"]

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -11,33 +11,35 @@ The application receives a number of command-line flags including the requests t
 
 ## Flags
 
-| Flag                              | Type    | Default value             | Description                                                                                                                                                                        |
-|:----------------------------------|:--------|:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -concurrency                      | int     | 2                         | Number of concurrent requests for warm up                                                                                                                                          |
-| -exit-after-warmup                | bool    | false                     | If warm up process should exit after completion                                                                                                                                    |
-| -grpc-headers                     | strings | N/A                       | gRPC headers to be sent with warm up requests. To send multiple headers define this flag for each header                                                                           |
-| -grpc-requests                    | strings | N/A                       | gRPC requests to be sent. Request is in '\<service\>\<method\>\[:message\]' format. E.g. health/ping:{"key": "value"}. To send multiple requests define this flag for each request |
-| -http-headers                     | strings | N/A                       | Http headers to be sent with warm up requests. To send multiple headers define this flag for each header                                                                           |
-| -http-requests                    | string  | N/A                       | Http request to be sent. Request is in '\<http-method\>:\<path\>\[:body\]' format. E.g. post:/ping:{"key": "value"}. To send multiple requests define this flag for each request   |
-| -file-probe-enabled               | bool    | true                      | If set to true writes files to be used as readiness/liveness probes                                                                                                                |
-| -file-probe-liveness-path         | string  | alive                     | File to be used for liveness probe                                                                                                                                                 |
-| -file-probe-readiness-path        | string  | ready                     | File to be used for readiness probe                                                                                                                                                |
-| -server-probe-enabled             | bool    | false                     | If set to true runs a web server that exposes endpoints to be used as readiness/liveness probes                                                                                    |
-| -server-probe-port                | int     | 8000                      | Port on which probe server is running                                                                                                                                              |
-| -server-probe-liveness-path       | string  | /alive                    | Probe server endpoint used as liveness probe                                                                                                                                       |
-| -server-probe-readiness-path      | string  | /ready                    | Probe server endpoint used as readiness probe                                                                                                                                      |
-| -profile-cpu                      | string  | ""                        | Name of the file where to write CPU profile data. If empty no CPU profiling takes place                                                                                            |
-| -profile-memory                   | string  | ""                        | Name of the file where to write memory profile data. If empty no memory profiling takes place                                                                                      |
-| -request-delay-milliseconds       | int     | 50                        | Delay in milliseconds between requests                                                                                                                                             |
-| -target-grpc-host                 | string  | localhost                 | gRPC host to warm up                                                                                                                                                               |
-| -target-grpc-port                 | int     | 50051                     | gRPC port for warm up requests                                                                                                                                                     |
-| -target-http-host                 | string  | http://localhost          | Http host to warm up                                                                                                                                                               |
-| -target-http-port                 | int     | 8080                      | Http port for warm up requests                                                                                                                                                     |
-| -target-insecure                  | bool    | false                     | Whether to skip TLS validation                                                                                                                                                     |
-| -target-readiness-path            | string  | /ready                    | The path used for target readiness probe                                                                                                                                           |
-| -target-readiness-port            | int     | same as -target-http-port | The port used for target readiness probe                                                                                                                                           |
-| -target-readiness-timeout-seconds | int     | -1                        | Timeout for target readiness probe                                                                                                                                                 |
-| -timeout-seconds                  | int     | 60                        | Time after which warm up will stop making requests                                                                                                                                 |
+| Flag                              | Type    | Default value               | Description                                                                                                                                                                        |
+|:----------------------------------|:--------|:----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -concurrency                      | int     | 2                           | Number of concurrent requests for warm up                                                                                                                                          |
+| -exit-after-warmup                | bool    | false                       | If warm up process should exit after completion                                                                                                                                    |
+| -grpc-headers                     | strings | N/A                         | gRPC headers to be sent with warm up requests. To send multiple headers define this flag for each header                                                                           |
+| -grpc-requests                    | strings | N/A                         | gRPC requests to be sent. Request is in '\<service\>\<method\>\[:message\]' format. E.g. health/ping:{"key": "value"}. To send multiple requests define this flag for each request |
+| -http-headers                     | strings | N/A                         | Http headers to be sent with warm up requests. To send multiple headers define this flag for each header                                                                           |
+| -http-requests                    | string  | N/A                         | Http request to be sent. Request is in '\<http-method\>:\<path\>\[:body\]' format. E.g. post:/ping:{"key": "value"}. To send multiple requests define this flag for each request   |
+| -file-probe-enabled               | bool    | true                        | If set to true writes files to be used as readiness/liveness probes                                                                                                                |
+| -file-probe-liveness-path         | string  | alive                       | File to be used for liveness probe                                                                                                                                                 |
+| -file-probe-readiness-path        | string  | ready                       | File to be used for readiness probe                                                                                                                                                |
+| -server-probe-enabled             | bool    | false                       | If set to true runs a web server that exposes endpoints to be used as readiness/liveness probes                                                                                    |
+| -server-probe-port                | int     | 8000                        | Port on which probe server is running                                                                                                                                              |
+| -server-probe-liveness-path       | string  | /alive                      | Probe server endpoint used as liveness probe                                                                                                                                       |
+| -server-probe-readiness-path      | string  | /ready                      | Probe server endpoint used as readiness probe                                                                                                                                      |
+| -profile-cpu                      | string  | ""                          | Name of the file where to write CPU profile data. If empty no CPU profiling takes place                                                                                            |
+| -profile-memory                   | string  | ""                          | Name of the file where to write memory profile data. If empty no memory profiling takes place                                                                                      |
+| -request-delay-milliseconds       | int     | 50                          | Delay in milliseconds between requests                                                                                                                                             |
+| -target-grpc-host                 | string  | localhost                   | gRPC host to warm up                                                                                                                                                               |
+| -target-grpc-port                 | int     | 50051                       | gRPC port for warm up requests                                                                                                                                                     |
+| -target-http-host                 | string  | http://localhost            | Http host to warm up                                                                                                                                                               |
+| -target-http-port                 | int     | 8080                        | Http port for warm up requests                                                                                                                                                     |
+| -target-insecure                  | bool    | false                       | Whether to skip TLS validation                                                                                                                                                     |
+| -target-readiness-grpc-method     | string  | grpc.health.v1.Health/Check | The service method used for gRPC target readiness probe                                                                                                                            |
+| -target-readiness-http-path       | string  | /ready                      | The path used for target readiness probe                                                                                                                                           |
+| -target-readiness-port            | int     | same as -target-http-port   | The port used for target readiness probe                                                                                                                                           |
+| -target-readiness-protocol        | string  | http                        | Protocol to be used for readiness check. One of [http, grpc]                                                                                                                       |
+| -target-readiness-timeout-seconds | int     | -1                          | Timeout for target readiness probe                                                                                                                                                 |
+| -timeout-seconds                  | int     | 60                          | Time after which warm up will stop making requests                                                                                                                                 |
 
 ### Warmup request
 A warmup request can be an HTTP one (over REST) or a gRPC one.
@@ -54,7 +56,8 @@ E.g.:
 
 #### gRPC requests
 
-gRPC requests are in the form `service/method[:message]` (`message` is optional). Host and port are taken from `target-grpc-host` and
+gRPC requests are in the form `service/method[:message]` (`message` is
+optional). Host and port are taken from `target-grpc-host` and
 `target-grpc-port` flags.
 
 #### Placeholders for dates
@@ -79,3 +82,11 @@ In case such probes are not needed you can disable this feature by setting `file
 
 Setting `server-probe-enabled` to `true` will start a web server that exposes liveness/readiness endpoints. 
 Note that running this web server instead of or in addition to having file probes increases memory and cpu consumption.
+
+### Health checks over HTTP and gRPC
+
+Mittens supports both HTTP and gRPC for application health checks.
+
+By default it uses HTTP to call the `-target-readiness-http-path` endpoint. If your app exposes a health check over gRPC you can set `-target-readiness-protocol` to `grpc` and define the RPC method to be called in `-target-readiness-grpc-method`. Method should be in the form `service/method`.
+See [here](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) on how to implement a gRPC health check on your applications. This has already been implemented in many languages including [Java](https://github.com/grpc/grpc-java/blob/master/services/src/main/proto/grpc/health/v1/health.proto) and [Go](https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto).
+Based on the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) the suggested format of service name is `grpc.health.v1.Health` which would translate to `-target-readiness-grpc-method=grpc.health.v1.Health/Check`.

--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -10,7 +10,7 @@ You can also run it as a linked Docker container or even as a sidecar in Kuberne
 
 You can run the binary executable as follows:
         
-    ./mittens -target-readiness-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-request=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\", \"bar\":\"foo\"}"
+    ./mittens -target-readiness-http-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-request=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\", \"bar\":\"foo\"}"
 
 To read the above configs from file:
 
@@ -20,7 +20,7 @@ where `configs.json`:
 
 ```json
 {
-  "target-readiness-path": "/health",
+  "target-readiness-http-path": "/health",
   "target-grpc-port": 6565,
   "timeout-seconds": 60,
   "concurrency": 3,
@@ -44,7 +44,7 @@ where `configs.json`:
         image: expediagroup/mittens:latest
         links:
           - app
-        command: "-target-readiness-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:{\"foo\":\"bar\", \"bar\":\"foo\"}"
+        command: "-target-readiness-http-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:{\"foo\":\"bar\", \"bar\":\"foo\"}"
 
 _Note_: If you use Docker for Mac you might need to set the target host (`target-http-host`, `target-grpc-host`) to `docker.for.mac.localhost`, or `docker.for.mac.host.internal`, or `host.docker.internal` (depending on your version of Docker) so that your container can resolve localhost.
 
@@ -98,12 +98,18 @@ spec:
         args:
         - "-concurrency=3"
         - "-timeout-seconds=60"
-        - "-target-readiness-path=/health"
+        - "-target-readiness-http-path=/health"
         - "-target-grpc-port=6565"
         - "-http-requests=get:/health"
         - "-http-requests=post:/hotel/aubergines:{\"foo\":\"bar\"}"
         - "-grpc-requests=service/method:{\"foo\":\"bar\",\"bar\":\"foo\"}"
 ```
+
+### gRPC health checks on Kubernetes
+
+Kubernetes does not natively support gRPC health checks.
+
+This leaves you with a couple of options which are documented [here](https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/).
 
 ## Notes about warm-up duration
 

--- a/pkg/grpc/utils.go
+++ b/pkg/grpc/utils.go
@@ -12,25 +12,31 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-package flags
+package grpc
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"testing"
+	"fmt"
+	"strings"
 )
 
-func TestHttp_ToHttpRequests(t *testing.T) {
+type Request struct {
+	ServiceMethod string
+	Message       string
+}
 
-	requestFlags := []string{
-		"get:/health",
-		"get:/ping",
+func ToGrpcRequest(requestFlag string) (Request, error) {
+
+	// service/method[:message]
+	parts := strings.SplitN(requestFlag, ":", 2)
+	if len(strings.Split(parts[0], "/")) != 2 {
+		return Request{}, fmt.Errorf("invalid request flag: %s, expected format <service>/<method>[:body]", requestFlag)
 	}
 
-	requests, err := toHttpRequests(requestFlags)
-	require.NoError(t, err)
-
-	require.Equal(t, 2, len(requests))
-	assert.Equal(t, "/health", requests[0].Path)
-	assert.Equal(t, "/ping", requests[1].Path)
+	request := Request{ServiceMethod: parts[0]}
+	if len(parts) == 2 {
+		request.Message = parts[1]
+	} else {
+		request.Message = ""
+	}
+	return request, nil
 }

--- a/pkg/grpc/utils_test.go
+++ b/pkg/grpc/utils_test.go
@@ -12,7 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-package flags
+package grpc
 
 import (
 	"github.com/stretchr/testify/assert"
@@ -20,17 +20,29 @@ import (
 	"testing"
 )
 
-func TestHttp_ToHttpRequests(t *testing.T) {
+func TestGrpc_FlagToGrpcRequest(t *testing.T) {
 
-	requestFlags := []string{
-		"get:/health",
-		"get:/ping",
-	}
-
-	requests, err := toHttpRequests(requestFlags)
+	requestFlag := `health/ping:{"db": "true"}`
+	request, err := ToGrpcRequest(requestFlag)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(requests))
-	assert.Equal(t, "/health", requests[0].Path)
-	assert.Equal(t, "/ping", requests[1].Path)
+	assert.Equal(t, "health/ping", request.ServiceMethod)
+	assert.Equal(t, `{"db": "true"}`, string(request.Message))
+}
+
+func TestGrpc_FlagWithoutBodyToGrpcRequest(t *testing.T) {
+
+	requestFlag := `health/ping`
+	request, err := ToGrpcRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, "health/ping", request.ServiceMethod)
+	assert.Equal(t, "", string(request.Message))
+}
+
+func TestGrpc_InvalidFlagToGrpcRequest(t *testing.T) {
+
+	requestFlag := `health:ping`
+	_, err := ToGrpcRequest(requestFlag)
+	require.Error(t, err)
 }

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -1,0 +1,93 @@
+//Copyright 2019 Expedia, Inc.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Request struct {
+	Method string
+	Path   string
+	Body   *string
+}
+
+var allowedHttpMethods = map[string]interface{}{
+	"GET":     nil,
+	"HEAD":    nil,
+	"POST":    nil,
+	"PUT":     nil,
+	"PATCH":   nil,
+	"DELETE":  nil,
+	"CONNECT": nil,
+	"OPTIONS": nil,
+	"TRACE":   nil,
+}
+
+var todayTemplateRegex = regexp.MustCompile("{(today([+-]\\d+)?|tomorrow)}")
+var todayTemplatePlusMinusRegex = regexp.MustCompile("[+-]\\d+")
+
+func ToHttpRequest(requestFlag string) (Request, error) {
+
+	parts := strings.SplitN(requestFlag, ":", 3)
+	if len(parts) < 2 {
+		return Request{}, fmt.Errorf("invalid request flag: %s, expected format <http-method>:<path>[:body]", requestFlag)
+	}
+
+	method := strings.ToUpper(parts[0])
+	_, ok := allowedHttpMethods[method]
+	if !ok {
+		return Request{}, fmt.Errorf("invalid request flag: %s, method %s is not supported", requestFlag, method)
+	}
+
+	// <method>:<path>
+	if len(parts) == 2 {
+		path := interpolateDates(parts[1])
+
+		return Request{
+			Method: method,
+			Path:   path,
+			Body:   nil,
+		}, nil
+	}
+
+	path := interpolateDates(parts[1])
+	var body = interpolateDates(parts[2])
+
+	return Request{
+		Method: method,
+		Path:   path,
+		Body:   &body,
+	}, nil
+}
+
+func interpolateDates(source string) string {
+	return todayTemplateRegex.ReplaceAllStringFunc(source, func(templateString string) string {
+		offsetDays := 0
+
+		if templateString == "{tomorrow}" {
+			offsetDays = 1
+		} else if extractedOffset := todayTemplatePlusMinusRegex.FindString(templateString); len(extractedOffset) > 0 {
+			offsetDays, _ = strconv.Atoi(extractedOffset)
+		}
+
+		// the date below is how the golang date formatter works. it's used for the formatting. it's not what is actually going to be displayed
+		return time.Now().Add(time.Duration(offsetDays) * 24 * time.Hour).Format("2006-01-02")
+	})
+}

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -1,0 +1,78 @@
+//Copyright 2019 Expedia, Inc.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestHttp_FlagToHttpRequest(t *testing.T) {
+
+	requestFlag := `post:/db:{"db": "true"}`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, request.Method)
+	assert.Equal(t, "/db", request.Path)
+	assert.Equal(t, `{"db": "true"}`, *request.Body)
+}
+
+func TestHttp_FlagWithoutBodyToHttpRequest(t *testing.T) {
+
+	requestFlag := `get:ping`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, request.Method)
+	assert.Equal(t, "ping", request.Path)
+	assert.Nil(t, request.Body)
+}
+
+func TestHttp_TodayInterpolation(t *testing.T) {
+
+	requestFlag := `post:/db_{today+5}:{"db": "{today+5}"}`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, request.Method)
+	date := time.Now().Add(time.Duration(5) * 24 * time.Hour).Format("2006-01-02") // today + 5
+	assert.Equal(t, "/db_"+date, request.Path)
+	assert.Equal(t, fmt.Sprintf(`{"db": "%s"}`, date), *request.Body)
+}
+
+func TestHttp_TomorrowInterpolation(t *testing.T) {
+
+	requestFlag := `post:/db_{tomorrow}:{"db": "{tomorrow}"}`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, request.Method)
+	date := time.Now().Add(time.Duration(1) * 24 * time.Hour).Format("2006-01-02") // today + 1
+	assert.Equal(t, "/db_"+date, request.Path)
+	assert.Equal(t, fmt.Sprintf(`{"db": "%s"}`, date), *request.Body)
+}
+
+func TestHttp_FlagWithInvalidMethodToHttpRequest(t *testing.T) {
+
+	requestFlag := `hmm:/ping:all=true`
+	_, err := ToHttpRequest(requestFlag)
+	require.Error(t, err)
+}
+


### PR DESCRIPTION
### :pencil: Description
This PR:
-  Adds support for gRPC healthchecks as suggested in #28 
- Fixes a couple of issues on the gRPC client. In specific, we were only setting timeouts for the RPCs and not for establishing the connection.
- Moves a couple of snippets under `pkg`.

### :link: Related Issues
#28 