### PR TITLE
Add support for randomized elements

### DIFF
--- a/cmd/flags/http.go
+++ b/cmd/flags/http.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"mittens/pkg/http"
-	"regexp"
 )
 
 var allowedHttpMethods = map[string]interface{}{
@@ -32,9 +31,6 @@ var allowedHttpMethods = map[string]interface{}{
 	"OPTIONS": nil,
 	"TRACE":   nil,
 }
-
-var todayTemplateRegex = regexp.MustCompile("{(today([+-]\\d+)?|tomorrow)}")
-var todayTemplatePlusMinusRegex = regexp.MustCompile("[+-]\\d+")
 
 type Http struct {
 	Headers  stringArray `json:"http-headers"`

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -70,6 +70,7 @@ The following are available:
 - {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.
 
 E.g.:
+ - `get:/some-path?date="{{currentDate|days+1,months+1,years+1}}"` 
  - `post:/some-path:{"id": "{{range|min=1,max=5}}", "currentDate": "{{currentDate|days+2,months+1}}"}`
 
 ### Liveness/readiness probes

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -60,16 +60,17 @@ gRPC requests are in the form `service/method[:message]` (`message` is
 optional). Host and port are taken from `target-grpc-host` and
 `target-grpc-port` flags.
 
-#### Placeholders for dates and randomized elements
+#### Placeholders for random elements
 
-Mittens allows you to use the keywords `{today}` and `{tomorrow}` when you need to use valid dates in your requests in the following format: YYYY-MM-DD.
-These placeholders can be used in both the urls and the body.
-You can also use modifiers with `{today}` to adjust to a specific offset, for example `{today+2}` to represent 2 days from now.
-
-If you need to generate random numbers of characters you can do the same with `{numbers-X}` or `{chars-X}` where X represents the lenght of the generated element.
+Mittens allows you to use special keywords if you need to generate randomized urls.
+The following are available:
+- {currentDate|days+x,months+y,years+z} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
+- {currentTimestamp} - Time from Unix epoch in milliseconds.
+- {random|foo,bar,baz} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz.
+- {range|min=x,max=y} - both min and max are required arguments. Range is inclusive.
 
 E.g.:
- - `post:/foo:{"id": "{numbers-5}", "date": "{today}"}`
+ - `post:/some-path:{"id": "{range|min=1,max=5}", "currentDate": "{currentDate|days+2,months+1}"}`
 
 ### Liveness/readiness probes
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -65,7 +65,7 @@ optional). Host and port are taken from `target-grpc-host` and
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
 - `{{currentDate|days+x,months+y,years+z}}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
-- {{currentTimestamp}} - Time from Unix epoch in milliseconds.
+- `{{currentTimestamp}}`: Time from Unix epoch in milliseconds.
 - `{{random|foo,bar,baz}}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -64,7 +64,7 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- {{currentDate|days+x,months+y,years+z}} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
+- `{{currentDate|days+x,months+y,years+z}}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
 - {{currentTimestamp}} - Time from Unix epoch in milliseconds.
 - {{random|foo,bar,baz}} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -60,14 +60,16 @@ gRPC requests are in the form `service/method[:message]` (`message` is
 optional). Host and port are taken from `target-grpc-host` and
 `target-grpc-port` flags.
 
-#### Placeholders for dates
+#### Placeholders for dates and randomized elements
 
 Mittens allows you to use the keywords `{today}` and `{tomorrow}` when you need to use valid dates in your requests in the following format: YYYY-MM-DD.
 These placeholders can be used in both the urls and the body.
 You can also use modifiers with `{today}` to adjust to a specific offset, for example `{today+2}` to represent 2 days from now.
 
+If you need to generate random numbers of characters you can do the same with `{numbers-X}` or `{chars-X}` where X represents the lenght of the generated element.
+
 E.g.:
- - `post:/foo:{"date": "{today}"}`
+ - `post:/foo:{"id": "{numbers-5}", "date": "{today}"}`
 
 ### Liveness/readiness probes
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -67,7 +67,7 @@ The following are available:
 - `{{currentDate|days+x,months+y,years+z}}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
 - `{{currentTimestamp}}`: Time from Unix epoch in milliseconds.
 - `{{random|foo,bar,baz}}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
-- {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.
+- `{{range|min=x,max=y}}`: both min and max are required arguments. Range is inclusive.
 
 E.g.:
  - `get:/some-path?date="{{currentDate|days+1,months+1,years+1}}"` 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -66,7 +66,7 @@ Mittens allows you to use special keywords if you need to generate randomized ur
 The following are available:
 - `{{currentDate|days+x,months+y,years+z}}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
 - {{currentTimestamp}} - Time from Unix epoch in milliseconds.
-- {{random|foo,bar,baz}} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
+- `{{random|foo,bar,baz}}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.
 
 E.g.:

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -66,7 +66,7 @@ Mittens allows you to use special keywords if you need to generate randomized ur
 The following are available:
 - {currentDate|days+x,months+y,years+z} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
 - {currentTimestamp} - Time from Unix epoch in milliseconds.
-- {random|foo,bar,baz} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz.
+- {random|foo,bar,baz} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - {range|min=x,max=y} - both min and max are required arguments. Range is inclusive.
 
 E.g.:

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -64,13 +64,13 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- {currentDate|days+x,months+y,years+z} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
-- {currentTimestamp} - Time from Unix epoch in milliseconds.
-- {random|foo,bar,baz} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
-- {range|min=x,max=y} - both min and max are required arguments. Range is inclusive.
+- {{currentDate|days+x,months+y,years+z}} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
+- {{currentTimestamp}} - Time from Unix epoch in milliseconds.
+- {{random|foo,bar,baz}} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
+- {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.
 
 E.g.:
- - `post:/some-path:{"id": "{range|min=1,max=5}", "currentDate": "{currentDate|days+2,months+1}"}`
+ - `post:/some-path:{"id": "{{range|min=1,max=5}}", "currentDate": "{{currentDate|days+2,months+1}}"}`
 
 ### Liveness/readiness probes
 

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -144,6 +145,11 @@ func rangeElements(source string) string {
 
 	min, _ := strconv.Atoi(r[1])
 	max, _ := strconv.Atoi(r[2])
+
+	if min > max {
+		log.Printf("Invalid range. min > max")
+		return source
+	}
 
 	number := rand.Intn(max-min+1) + min
 

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -43,7 +43,7 @@ var allowedHttpMethods = map[string]interface{}{
 
 var templatePlaceholderRegex = regexp.MustCompile("{(\\w+([\\|+][\\w+-=,]+)?|(\\w+))}")
 var templateRangeRegex = regexp.MustCompile("{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
-var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w]+)}")
+var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w-]+)}")
 var templateDatesRegex = regexp.MustCompile("{currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}") // we did it \o/ 100+ chars regex
 
 // The following regex expressions are deprecated

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -23,9 +23,6 @@ import (
 	"time"
 )
 
-const lettersAndNumbers = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-const numbers = "0123456789"
-
 type Request struct {
 	Method string
 	Path   string

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -101,6 +101,10 @@ func legacyDateElements(source string) string {
 
 func dateElements(source string) string {
 	r := templateDatesRegex.FindStringSubmatch(source)
+
+	if r == nil {
+		return source
+	}
 	days := r[1]
 	months := r[2]
 	years := r[3]
@@ -121,8 +125,12 @@ func timestampElements() string {
 
 func randomElements(source string) string {
 	r := templateElementsRegex.FindStringSubmatch(source)
-	s := strings.Split(r[1], ",")
 
+	if r == nil {
+		return source
+	}
+
+	s := strings.Split(r[1], ",")
 	number := rand.Intn(len(s))
 
 	return s[number]
@@ -130,7 +138,11 @@ func randomElements(source string) string {
 
 func rangeElements(source string) string {
 	r := templateRangeRegex.FindStringSubmatch(source)
-	min, _ := strconv.Atoi(r[1]) // FIXME replace _ with error or better yet when these inner fail just return original string
+	if r == nil {
+		return source
+	}
+
+	min, _ := strconv.Atoi(r[1])
 	max, _ := strconv.Atoi(r[2])
 
 	number := rand.Intn(max-min+1) + min

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -46,7 +46,7 @@ func TestHttp_FlagWithoutBodyToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_DateInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{currentDate}:{"db": "{currentDate|days+5,months+2,years-1}"}`
+	requestFlag := `post:/db_{{currentDate}}:{"date": "{{currentDate|days+5,months+2,years-1}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -54,29 +54,7 @@ func TestHttp_DateInterpolation(t *testing.T) {
 	dateToday := time.Now().Format("2006-01-02")                        // today + 5
 	dateWithOffset := time.Now().AddDate(-1, 2, 5).Format("2006-01-02") // today -1 year, +2 months, +5 days
 	assert.Equal(t, "/db_"+dateToday, request.Path)
-	assert.Equal(t, fmt.Sprintf(`{"db": "%s"}`, dateWithOffset), *request.Body)
-}
-
-func TestHttp_TodayInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{today+5}:{"db": "{today+5}"}`
-	request, err := ToHttpRequest(requestFlag)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.MethodPost, request.Method)
-	date := time.Now().Add(time.Duration(5) * 24 * time.Hour).Format("2006-01-02") // today + 5
-	assert.Equal(t, "/db_"+date, request.Path)
-	assert.Equal(t, fmt.Sprintf(`{"db": "%s"}`, date), *request.Body)
-}
-
-func TestHttp_TomorrowInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{tomorrow}:{"db": "{tomorrow}"}`
-	request, err := ToHttpRequest(requestFlag)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.MethodPost, request.Method)
-	date := time.Now().Add(time.Duration(1) * 24 * time.Hour).Format("2006-01-02") // today + 1
-	assert.Equal(t, "/db_"+date, request.Path)
-	assert.Equal(t, fmt.Sprintf(`{"db": "%s"}`, date), *request.Body)
+	assert.Equal(t, fmt.Sprintf(`{"date": "%s"}`, dateWithOffset), *request.Body)
 }
 
 func TestHttp_FlagWithInvalidMethodToHttpRequest(t *testing.T) {
@@ -86,7 +64,7 @@ func TestHttp_FlagWithInvalidMethodToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_TimestampInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{currentTimestamp}:{"body": "{currentTimestamp}"}`
+	requestFlag := `post:/path_{{currentTimestamp}}:{"body": "{{currentTimestamp}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -103,7 +81,7 @@ func TestHttp_TimestampInterpolation(t *testing.T) {
 }
 
 func TestHttp_RangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{range|min=1,max=2}:{"body": "{range|min=1,max=2}"}`
+	requestFlag := `post:/path_{{range|min=1,max=2}}:{"body": "{{range|min=1,max=2}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -120,19 +98,19 @@ func TestHttp_RangeInterpolation(t *testing.T) {
 }
 
 func TestHttp_InvalidRangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{range|min=2,max=1}:{"body": "{range|min=2,max=1}"}`
+	requestFlag := `post:/path_{{range|min=2,max=1}}:{"body": "{{range|min=2,max=1}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
 	// will not action on invalid ranges
-	assert.Equal(t, request.Path, "/path_{range|min=2,max=1}")
-	assert.Equal(t, *request.Body, "{\"body\": \"{range|min=2,max=1}\"}")
+	assert.Equal(t, request.Path, "/path_{{range|min=2,max=1}}")
+	assert.Equal(t, *request.Body, "{\"body\": \"{{range|min=2,max=1}}\"}")
 }
 
 func TestHttp_RandomElementInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{random|fo-o,b_ar}:{"body": "{random|fo-o,b_ar}"}`
+	requestFlag := `post:/path_{{random|fo-o,b_ar}}:{"body": "{{random|fo-o,b_ar}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -120,13 +120,13 @@ func TestHttp_RangeInterpolation(t *testing.T) {
 }
 
 func TestHttp_RandomElementInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{random|foo,bar}:{"body": "{random|foo,bar}"}`
+	requestFlag := `post:/path_{random|fo-o,b_ar}:{"body": "{random|fo-o,b_ar}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
-	var elementsRegex = regexp.MustCompile("[foo|bar]")
+	var elementsRegex = regexp.MustCompile("[fo-o|b_ar]")
 	matchPath := elementsRegex.MatchString(request.Path)
 	matchBody := elementsRegex.MatchString(*request.Body)
 

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -81,16 +81,16 @@ func TestHttp_TimestampInterpolation(t *testing.T) {
 }
 
 func TestHttp_MultipleInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{range|min=1,max=2}}_{{random|foo,bar}}:{"body": "{{random|foo}} {{range|min=1,max=2}}"}`
+	requestFlag := `post:/path_{{range|min=1,max=2}}_{{random|foo,bar}}:{"body": "{{random|foo,bar}} {{range|min=1,max=2}}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
-	var pathRegex = regexp.MustCompile("/path_\\d_[foo|bar]")
+	var pathRegex = regexp.MustCompile("/path_\\d_(foo|bar)")
 	matchPath := pathRegex.MatchString(request.Path)
 
-	var bodyRegex = regexp.MustCompile("{\"body\": \"foo \\d\"}")
+	var bodyRegex = regexp.MustCompile("{\"body\": \"(foo|bar) \\d\"}")
 	matchBody := bodyRegex.MatchString(*request.Body)
 
 	assert.True(t, matchPath)
@@ -133,7 +133,7 @@ func TestHttp_RandomElementInterpolation(t *testing.T) {
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
-	var elementsRegex = regexp.MustCompile("[fo-o|b_ar]")
+	var elementsRegex = regexp.MustCompile("(fo-o|b_ar)")
 	matchPath := elementsRegex.MatchString(request.Path)
 	matchBody := elementsRegex.MatchString(*request.Body)
 

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -119,6 +119,18 @@ func TestHttp_RangeInterpolation(t *testing.T) {
 	assert.True(t, matchBody)
 }
 
+func TestHttp_InvalidRangeInterpolation(t *testing.T) {
+	requestFlag := `post:/path_{range|min=2,max=1}:{"body": "{range|min=2,max=1}"}`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, request.Method)
+
+	// will not action on invalid ranges
+	assert.Equal(t, request.Path, "/path_{range|min=2,max=1}")
+	assert.Equal(t, *request.Body, "{\"body\": \"{range|min=2,max=1}\"}")
+}
+
 func TestHttp_RandomElementInterpolation(t *testing.T) {
 	requestFlag := `post:/path_{random|fo-o,b_ar}:{"body": "{random|fo-o,b_ar}"}`
 	request, err := ToHttpRequest(requestFlag)

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -80,6 +80,23 @@ func TestHttp_TimestampInterpolation(t *testing.T) {
 	assert.Equal(t, len(*request.Body), 25) // { "body": 13 numbers for timestamp
 }
 
+func TestHttp_MultipleInterpolation(t *testing.T) {
+	requestFlag := `post:/path_{{range|min=1,max=2}}_{{random|foo,bar}}:{"body": "{{random|foo}} {{range|min=1,max=2}}"}`
+	request, err := ToHttpRequest(requestFlag)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, request.Method)
+
+	var pathRegex = regexp.MustCompile("/path_\\d_[foo|bar]")
+	matchPath := pathRegex.MatchString(request.Path)
+
+	var bodyRegex = regexp.MustCompile("{\"body\": \"foo \\d\"}")
+	matchBody := bodyRegex.MatchString(*request.Body)
+
+	assert.True(t, matchPath)
+	assert.True(t, matchBody)
+}
+
 func TestHttp_RangeInterpolation(t *testing.T) {
 	requestFlag := `post:/path_{{range|min=1,max=2}}:{"body": "{{range|min=1,max=2}}"}`
 	request, err := ToHttpRequest(requestFlag)


### PR DESCRIPTION
### :pencil: Description
- Add support for random elements.
- This is useful to systems that use remote caches and where the warmup fails to exercise the paths for cache misses.

### Random elements added:
- {{currentDate|days+x,months+y,years+z}} - you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
- {{currentTimestamp}} - Time from Unix epoch in milliseconds.
- {{random|foo,bar,baz}} - Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
- {{range|min=x,max=y}} - both min and max are required arguments. Range is inclusive.