### PR TITLE
Replacing double with single brackets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ build: unit-tests
 	@CGO_ENABLED=0 go build
 
 docker:
-	@docker build -t mittens .
+	@docker build -t expediagroup/mittens:latest .

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -67,7 +67,7 @@ The following are available:
 - `{currentDate|days+x,months+y,years+z}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
 - `{currentTimestamp}`: Time from Unix epoch in milliseconds.
 - `{random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
-- `{{range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.
+- `{range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.
 
 E.g.:
  - `get:/some-path?date="{currentDate|days+1,months+1,years+1}"` 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -64,14 +64,14 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- `{currentDate|days+x,months+y,years+z}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
-- `{currentTimestamp}`: Time from Unix epoch in milliseconds.
-- `{random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
-- `{range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.
+- `{$currentDate|days+x,months+y,years+z}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
+- `{$currentTimestamp}`: Time from Unix epoch in milliseconds.
+- `{$random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
+- `{$range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.
 
 E.g.:
- - `get:/some-path?date="{currentDate|days+1,months+1,years+1}"` 
- - `post:/some-path:{"id": "{range|min=1,max=5}", "currentDate": "{currentDate|days+2,months+1}"}`
+ - `get:/some-path?date="{$currentDate|days+1,months+1,years+1}"` 
+ - `post:/some-path:{"id": "{$range|min=1,max=5}", "currentDate": "{$currentDate|days+2,months+1}"}`
 
 ### Liveness/readiness probes
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -64,14 +64,14 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- `{{currentDate|days+x,months+y,years+z}}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
-- `{{currentTimestamp}}`: Time from Unix epoch in milliseconds.
-- `{{random|foo,bar,baz}}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
-- `{{range|min=x,max=y}}`: both min and max are required arguments. Range is inclusive.
+- `{currentDate|days+x,months+y,years+z}`: you can adjust the temporal offset by adding or subtracting days, months or years. The offsets are optional and can be removed.
+- `{currentTimestamp}`: Time from Unix epoch in milliseconds.
+- `{random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
+- `{{range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.
 
 E.g.:
- - `get:/some-path?date="{{currentDate|days+1,months+1,years+1}}"` 
- - `post:/some-path:{"id": "{{range|min=1,max=5}}", "currentDate": "{{currentDate|days+2,months+1}}"}`
+ - `get:/some-path?date="{currentDate|days+1,months+1,years+1}"` 
+ - `post:/some-path:{"id": "{range|min=1,max=5}", "currentDate": "{currentDate|days+2,months+1}"}`
 
 ### Liveness/readiness probes
 

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -42,10 +42,11 @@ var allowedHttpMethods = map[string]interface{}{
 	"TRACE":   nil,
 }
 
-var templatePlaceholderRegex = regexp.MustCompile("{{(\\w+([\\|+][\\w+-=,]+)?|(\\w+))}}")
-var templateRangeRegex = regexp.MustCompile("{{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}}")
-var templateElementsRegex = regexp.MustCompile("{{random\\|(?P<Elements>[,\\w-]+)}}")
-var templateDatesRegex = regexp.MustCompile("{{currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}}") // we did it \o/ 100+ chars regex
+// any thing that starts with { followed by any word character and optinally followed by modifiers in the format |word=word,word=word,...
+var templatePlaceholderRegex = regexp.MustCompile("{(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}")
+var templateRangeRegex = regexp.MustCompile("{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
+var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w-]+)}")
+var templateDatesRegex = regexp.MustCompile("{currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}") // we did it \o/ 100+ chars regex
 
 func ToHttpRequest(requestFlag string) (Request, error) {
 	parts := strings.SplitN(requestFlag, ":", 3)

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -42,8 +42,7 @@ var allowedHttpMethods = map[string]interface{}{
 	"TRACE":   nil,
 }
 
-// any thing that starts with { followed by any word character and optinally followed by a modifier identifier | and the modifiers that can contain word chars + - and =
-var templatePlaceholderRegex = regexp.MustCompile("{(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}")
+var templatePlaceholderRegex = regexp.MustCompile("{(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}") // anything that starts with { followed by any word character and optinally followed by a modifier identifier | and the modifiers that can contain word chars + - and =
 var templateRangeRegex = regexp.MustCompile("{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
 var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w-]+)}")
 var templateDatesRegex = regexp.MustCompile("{currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}") // we did it \o/ 100+ chars regex

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -42,7 +42,7 @@ var allowedHttpMethods = map[string]interface{}{
 	"TRACE":   nil,
 }
 
-// any thing that starts with { followed by any word character and optinally followed by modifiers in the format |word=word,word=word,...
+// any thing that starts with { followed by any word character and optinally followed by a modifier identifier | and the modifiers that can contain word chars + - and =
 var templatePlaceholderRegex = regexp.MustCompile("{(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}")
 var templateRangeRegex = regexp.MustCompile("{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
 var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w-]+)}")

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -42,10 +42,10 @@ var allowedHttpMethods = map[string]interface{}{
 	"TRACE":   nil,
 }
 
-var templatePlaceholderRegex = regexp.MustCompile("{(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}") // anything that starts with { followed by any word character and optinally followed by a modifier identifier | and the modifiers that can contain word chars + - and =
-var templateRangeRegex = regexp.MustCompile("{range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
-var templateElementsRegex = regexp.MustCompile("{random\\|(?P<Elements>[,\\w-]+)}")
-var templateDatesRegex = regexp.MustCompile("{currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}") // we did it \o/ 100+ chars regex
+var templatePlaceholderRegex = regexp.MustCompile("{\\$(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}") // anything that starts with {$ followed by any word character and optinally followed by a modifier identifier | and the modifiers that can contain word chars + - = and ,
+var templateRangeRegex = regexp.MustCompile("{\\$range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
+var templateElementsRegex = regexp.MustCompile("{\\$random\\|(?P<Elements>[,\\w-]+)}")
+var templateDatesRegex = regexp.MustCompile("{\\$currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}") // we did it \o/ 100+ chars regex
 
 func ToHttpRequest(requestFlag string) (Request, error) {
 	parts := strings.SplitN(requestFlag, ":", 3)

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -46,7 +46,7 @@ func TestHttp_FlagWithoutBodyToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_DateInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{{currentDate}}:{"date": "{{currentDate|days+5,months+2,years-1}}"}`
+	requestFlag := `post:/db_{currentDate}:{"date": "{currentDate|days+5,months+2,years-1}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func TestHttp_FlagWithInvalidMethodToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_TimestampInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{currentTimestamp}}:{"body": "{{currentTimestamp}}"}`
+	requestFlag := `post:/path_{currentTimestamp}:{"body": "{currentTimestamp}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestHttp_TimestampInterpolation(t *testing.T) {
 }
 
 func TestHttp_MultipleInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{range|min=1,max=2}}_{{random|foo,bar}}:{"body": "{{random|foo,bar}} {{range|min=1,max=2}}"}`
+	requestFlag := `post:/path_{range|min=1,max=2}_{random|foo,bar}:{"body": "{random|foo,bar} {range|min=1,max=2}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func TestHttp_MultipleInterpolation(t *testing.T) {
 }
 
 func TestHttp_RangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{range|min=1,max=2}}:{"body": "{{range|min=1,max=2}}"}`
+	requestFlag := `post:/path_{range|min=1,max=2}:{"body": "{range|min=1,max=2}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -115,19 +115,19 @@ func TestHttp_RangeInterpolation(t *testing.T) {
 }
 
 func TestHttp_InvalidRangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{range|min=2,max=1}}:{"body": "{{range|min=2,max=1}}"}`
+	requestFlag := `post:/path_{range|min=2,max=1}:{"body": "{range|min=2,max=1}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
 	// will not action on invalid ranges
-	assert.Equal(t, request.Path, "/path_{{range|min=2,max=1}}")
-	assert.Equal(t, *request.Body, "{\"body\": \"{{range|min=2,max=1}}\"}")
+	assert.Equal(t, request.Path, "/path_{range|min=2,max=1}")
+	assert.Equal(t, *request.Body, "{\"body\": \"{range|min=2,max=1}\"}")
 }
 
 func TestHttp_RandomElementInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{{random|fo-o,b_ar}}:{"body": "{{random|fo-o,b_ar}}"}`
+	requestFlag := `post:/path_{random|fo-o,b_ar}:{"body": "{random|fo-o,b_ar}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -46,7 +46,7 @@ func TestHttp_FlagWithoutBodyToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_DateInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{currentDate}:{"date": "{currentDate|days+5,months+2,years-1}"}`
+	requestFlag := `post:/db_{$currentDate}:{"date": "{$currentDate|days+5,months+2,years-1}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func TestHttp_FlagWithInvalidMethodToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_TimestampInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{currentTimestamp}:{"body": "{currentTimestamp}"}`
+	requestFlag := `post:/path_{$currentTimestamp}:{"body": "{$currentTimestamp}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestHttp_TimestampInterpolation(t *testing.T) {
 }
 
 func TestHttp_MultipleInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{range|min=1,max=2}_{random|foo,bar}:{"body": "{random|foo,bar} {range|min=1,max=2}"}`
+	requestFlag := `post:/path_{$range|min=1,max=2}_{$random|foo,bar}:{"body": "{$random|foo,bar} {$range|min=1,max=2}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func TestHttp_MultipleInterpolation(t *testing.T) {
 }
 
 func TestHttp_RangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{range|min=1,max=2}:{"body": "{range|min=1,max=2}"}`
+	requestFlag := `post:/path_{$range|min=1,max=2}:{"body": "{$range|min=1,max=2}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
@@ -115,19 +115,19 @@ func TestHttp_RangeInterpolation(t *testing.T) {
 }
 
 func TestHttp_InvalidRangeInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{range|min=2,max=1}:{"body": "{range|min=2,max=1}"}`
+	requestFlag := `post:/path_{$range|min=2,max=1}:{"body": "{$range|min=2,max=1}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
 
 	// will not action on invalid ranges
-	assert.Equal(t, request.Path, "/path_{range|min=2,max=1}")
-	assert.Equal(t, *request.Body, "{\"body\": \"{range|min=2,max=1}\"}")
+	assert.Equal(t, request.Path, "/path_{$range|min=2,max=1}")
+	assert.Equal(t, *request.Body, "{\"body\": \"{$range|min=2,max=1}\"}")
 }
 
 func TestHttp_RandomElementInterpolation(t *testing.T) {
-	requestFlag := `post:/path_{random|fo-o,b_ar}:{"body": "{random|fo-o,b_ar}"}`
+	requestFlag := `post:/path_{$random|fo-o,b_ar}:{"body": "{$random|fo-o,b_ar}"}`
 	request, err := ToHttpRequest(requestFlag)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### :pencil: Description
It turns out that using double brackets is a bad idea when we mix this with helm templates (it tries to run the placeholders as functions and fails because "random", ... don't exist).
Since that is the primary use case (kube/helm) for this warmup i'm replacing those with single brackets.