### PR TITLE
#36 GitHub Action for publishing docs.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,37 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - 'website/**'
+
+jobs:
+  publish-docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Build
+        run: |
+          cd website
+          npm install
+          npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build/mittens
+          publish_branch: gh-pages
+          user_name: eg-oss-ci
+          user_email: oss@expediagroup.com


### PR DESCRIPTION
# :pencil: Description
- GitHub Action for publishing docs
- Uses https://github.com/peaceiris/actions-gh-pages and the automatically created [GITHUB_TOKEN](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) which now works for public repos as well 🎉
- Author of commit is the `eg-oss-ci` user

### :link: Related Issues