### PR TITLE
Fix project name in publish directory used in action.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build/mittens
-          publish_branch: gh-pages
+          publish_dir: ./website/build/Mittens
           user_name: eg-oss-ci
           user_email: oss@expediagroup.com


### PR DESCRIPTION
### :pencil: Description
- Action uses the `projectName` from [here](https://github.com/ExpediaGroup/mittens/blob/06bd2db8e4770cdada4bcdbe41e25332cbdacd68/website/siteConfig.js#L32), not the repo name

### :link: Related Issues 