### PR TITLE
[#30] Rename flag -timeout-seconds to -max-duration-seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,13 @@
-.PHONY: all build unit-tests integration-tests
+.PHONY: build unit-tests integration-tests
 
 override GOOS:=$(shell uname)
 override GO111MODULE=on
 
-all: build
-
 unit-tests:
-	@go test ./...
+	@CGO_ENABLED=0 go build && go test ./...
 
 integration-tests:
 	@go test -tags=integration ./...
-
-build: unit-tests
-	@CGO_ENABLED=0 go build
 
 docker:
 	@docker build -t expediagroup/mittens:latest .

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To run the integration tests:
 
 To run the binary:
         
-    ./mittens -target-readiness-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\",\"bar\":\"foo\"}"
+    ./mittens -target-readiness-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\",\"bar\":\"foo\"}"
 
 ### Docker
 #### Build image
@@ -71,7 +71,7 @@ To build a Docker image named `mittens`:
 
 To run the container:
 
-    docker run mittens:latest -target-readiness-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\",\"bar\":\"foo\"}"
+    docker run mittens:latest -target-readiness-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\",\"bar\":\"foo\"}"
 
 _Note_: If you use Docker for Mac you might need to set the target host (`target-http-host`, `target-grpc-host`) to `docker.for.mac.localhost`, or `docker.for.mac.host.internal`, or `host.docker.internal` (depending on your version of Docker) so that your container can resolve localhost.
 

--- a/README.md
+++ b/README.md
@@ -34,20 +34,14 @@ We provide a [Makefile](Makefile) which can be used to generate an executable bi
 
 To build the binary make sure you've installed [Go 1.13](https://golang.org/dl/).
 
-#### Build binary executable
+#### Build binary executable & run unit tests
 
 To build the project run the following:
 
-    make build
-
-This will generate a binary executable.
-
-#### Run unit tests
-
-To run the tests:
-
     make unit-tests
-    
+
+This will run the unit tests and generate a binary executable.
+
 #### Run integration tests
 
 To run the integration tests:

--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -58,8 +58,8 @@ func (r *Root) InitFlags() {
 func (r *Root) GetWarmupOptions() warmup.Options {
 
 	return warmup.Options{
-		TimeoutSeconds: r.MaxDurationSeconds,
-		Concurrency:    r.Concurrency,
+		MaxDurationSeconds: r.MaxDurationSeconds,
+		Concurrency:        r.Concurrency,
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -57,7 +57,7 @@ func TestWarmupSidecarWithFileProbe(t *testing.T) {
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
 	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
-	assert.Equal(t, 5, opts.TimeoutSeconds)
+	assert.Equal(t, 5, opts.MaxDurationSeconds)
 }
 
 func TestWarmupSidecarWithServerProbe(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWarmupSidecarWithServerProbe(t *testing.T) {
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
 	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
-	assert.Equal(t, 5, opts.TimeoutSeconds)
+	assert.Equal(t, 5, opts.MaxDurationSeconds)
 }
 
 func TestConfigsFromFile(t *testing.T) {
@@ -95,7 +95,7 @@ func TestConfigsFromFile(t *testing.T) {
 	assert.Equal(t, 4, opts.Concurrency)
 	assert.Equal(t, true, opts.ExitAfterWarmup)
 	assert.Equal(t, "/", opts.Target.ReadinessHttpPath)
-	assert.Equal(t, 5, opts.TimeoutSeconds)
+	assert.Equal(t, 5, opts.MaxDurationSeconds)
 }
 
 func StartTargetTestServer(t *testing.T) (shutdown func()) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -46,7 +46,7 @@ func TestWarmupSidecarWithFileProbe(t *testing.T) {
 		"-concurrency=4",
 		"-exit-after-warmup=true",
 		"-target-readiness-http-path=/",
-		"-timeout-seconds=5"}
+		"-max-duration-seconds=5"}
 
 	CreateConfig()
 	RunCmdRoot()
@@ -68,7 +68,7 @@ func TestWarmupSidecarWithServerProbe(t *testing.T) {
 		"-concurrency=4",
 		"-exit-after-warmup=true",
 		"-target-readiness-http-path=/",
-		"-timeout-seconds=5"}
+		"-max-duration-seconds=5"}
 
 	CreateConfig()
 	RunCmdRoot()

--- a/cmd/sample_configs.json
+++ b/cmd/sample_configs.json
@@ -1,6 +1,6 @@
 {
   "exit-after-warmup": true,
-  "timeout-seconds": 5,
+  "max-duration-seconds": 5,
   "concurrency": 4,
   "target-readiness-http-path": "/",
   "file-probe-enabled": true,

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -39,7 +39,7 @@ The application receives a number of command-line flags including the requests t
 | -target-readiness-port            | int     | same as -target-http-port   | The port used for target readiness probe                                                                                                                                           |
 | -target-readiness-protocol        | string  | http                        | Protocol to be used for readiness check. One of [http, grpc]                                                                                                                       |
 | -target-readiness-timeout-seconds | int     | -1                          | Timeout for target readiness probe                                                                                                                                                 |
-| -timeout-seconds                  | int     | 60                          | Time after which warm up will stop making requests                                                                                                                                 |
+| -max-duration-seconds             | int     | 60                          | Maximum duration in seconds after which warm up will stop making requests                                                                                                                                 |
 
 ### Warmup request
 A warmup request can be an HTTP one (over REST) or a gRPC one.

--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -22,7 +22,7 @@ where `configs.json`:
 {
   "target-readiness-http-path": "/health",
   "target-grpc-port": 6565,
-  "timeout-seconds": 60,
+  "max-duration-seconds": 60,
   "concurrency": 3,
   "http-requests": ["get:/hotel/potatoes"],
   "grpc-requests": ["service/method:'{\"foo\":\"bar\", \"bar\":\"foo\"}'"]

--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -10,7 +10,7 @@ You can also run it as a linked Docker container or even as a sidecar in Kuberne
 
 You can run the binary executable as follows:
         
-    ./mittens -target-readiness-http-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-request=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\", \"bar\":\"foo\"}"
+    ./mittens -target-readiness-http-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-request=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\", \"bar\":\"foo\"}"
 
 To read the above configs from file:
 
@@ -44,7 +44,7 @@ where `configs.json`:
         image: expediagroup/mittens:latest
         links:
           - app
-        command: "-target-readiness-http-path=/health -target-grpc-port=6565 -timeout-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:{\"foo\":\"bar\", \"bar\":\"foo\"}"
+        command: "-target-readiness-http-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:{\"foo\":\"bar\", \"bar\":\"foo\"}"
 
 _Note_: If you use Docker for Mac you might need to set the target host (`target-http-host`, `target-grpc-host`) to `docker.for.mac.localhost`, or `docker.for.mac.host.internal`, or `host.docker.internal` (depending on your version of Docker) so that your container can resolve localhost.
 
@@ -97,7 +97,7 @@ spec:
           periodSeconds: 30
         args:
         - "-concurrency=3"
-        - "-timeout-seconds=60"
+        - "-max-duration-seconds=60"
         - "-target-readiness-http-path=/health"
         - "-target-grpc-port=6565"
         - "-http-requests=get:/health"
@@ -115,11 +115,11 @@ This leaves you with a couple of options which are documented [here](https://kub
 
 Be aware that setting **target-readiness-timeout-seconds** will change how long the warmup routine will run for.
 
-### Option 1: setting just -timeout-seconds
+### Option 1: setting just -max-duration-seconds
 
 ```
 "-server-probe-readiness-path": /ready
-"-timeout-seconds": 90
+"-max-duration-seconds": 90
 "-http-requests": someRequest
 "-http-requests": anotherRequest
 ```
@@ -131,11 +131,11 @@ Note that during the warmup _someRequest_ and _anotherRequest_ will be called ra
 
 If the application is not ready after 90 seconds, we skip the warmup routine.
 
-### Option 2: setting -timeout-seconds and -target-readiness-timeout-seconds
+### Option 2: setting -max-duration-seconds and -target-readiness-timeout-seconds
 
 ```
 "-server-probe-readiness-path": /ready
-"-timeout-seconds": 90
+"-max-duration-seconds": 90
 "-target-readiness-timeout-seconds": 60
 "-http-requests": someRequest
 "-http-requests": anotherRequest

--- a/pkg/warmup/warmup.go
+++ b/pkg/warmup/warmup.go
@@ -24,8 +24,8 @@ import (
 )
 
 type Options struct {
-	TimeoutSeconds int
-	Concurrency    int
+	MaxDurationSeconds int
+	Concurrency        int
 }
 
 type Warmup struct {


### PR DESCRIPTION
### :pencil: Description
Rename flag -timeout-seconds to -max-duration-seconds for better understanding of what it is

### :link: Related Issues
#30 