### PR TITLE
[#59] Drop support for target-readiness-timeout-seconds.

### DIFF
--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -83,10 +83,7 @@ func (r *Root) GetGrpcClient() grpc.Client {
 func (r *Root) GetWarmupTargetOptions() (warmup.TargetOptions, error) {
 
 	options := r.Target.GetWarmupTargetOptions()
-	if options.ReadinessTimeoutInSeconds <= 0 {
-		log.Printf("Readiness timeout in seconds not set, defaulting to max duration in seconds: %ds", r.MaxDurationSeconds)
-		options.ReadinessTimeoutInSeconds = r.MaxDurationSeconds
-	}
+	options.ReadinessTimeoutInSeconds = r.MaxDurationSeconds
 	if options.ReadinessProtocol != "http" && options.ReadinessProtocol != "grpc" {
 		err := fmt.Errorf("Readiness protocol %s not supported, please use http or grpc", r.ReadinessProtocol)
 		return options, err

--- a/cmd/flags/target.go
+++ b/cmd/flags/target.go
@@ -48,7 +48,6 @@ func (t *Target) InitFlags() {
 	flag.StringVar(&t.ReadinessHttpPath, "target-readiness-http-path", "/ready", "The path used for HTTP target readiness probe")
 	flag.StringVar(&t.ReadinessGrpcMethod, "target-readiness-grpc-method", "grpc.health.v1.Health/Check", "The service method used for gRPC target readiness probe")
 	flag.IntVar(&t.ReadinessPort, "target-readiness-port", toIntOrDefaultIfNull(&t.HttpPort, 8080), "The port used for target readiness probe")
-	flag.IntVar(&t.ReadinessTimeoutSeconds, "target-readiness-timeout-seconds", -1, "Timeout for target readiness probe")
 	flag.BoolVar(&t.Insecure, "target-insecure", false, "Whether to skip TLS validation")
 }
 

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -37,7 +37,6 @@ The application receives a number of command-line flags including the requests t
 | -target-readiness-http-path       | string  | /ready                      | The path used for target readiness probe                                                                                                                                           |
 | -target-readiness-port            | int     | same as -target-http-port   | The port used for target readiness probe                                                                                                                                           |
 | -target-readiness-protocol        | string  | http                        | Protocol to be used for readiness check. One of [`http`, `grpc`]                                                                                                                   |
-| -target-readiness-timeout-seconds | int     | -1                          | Maximum time to wait for the target to become ready. If not ready, Mittens will simply skip the warmup.                                                                            |
 | -max-duration-seconds             | int     | 60                          | Maximum duration in seconds after which warm up will stop making requests                                                                                                          |
 
 ### Warmup request

--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -94,39 +94,10 @@ Kubernetes does not natively support gRPC health checks.
 
 This leaves you with a couple of options which are documented [here](https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/).
 
-## Notes about warm-up duration
+## Note about warm-up duration
 
-Be aware that setting **target-readiness-timeout-seconds** will change how long the warmup routine will run for.
-
-### Option 1: setting just -max-duration-seconds
-
-```
-"-server-probe-readiness-path": /ready
-"-max-duration-seconds": 90
-"-http-requests": someRequest
-"-http-requests": anotherRequest
-```
-
-With these configs the mittens container will start to call _/ready_.
+`-max-duration-seconds` includes the time needed for your application to start.
 Let's say that your application takes 30 seconds to start (ie, for _/ready_ to start returning 200).
 What happens is that after these initial 30 seconds, mittens will start but it will only run for 60 seconds. This is because we already spent 30 seconds waiting for the app to start.
-Note that during the warmup _someRequest_ and _anotherRequest_ will be called randomly and not in any particular order.
 
 If the application is not ready after 90 seconds, we skip the warmup routine.
-
-### Option 2: setting -max-duration-seconds and -target-readiness-timeout-seconds
-
-```
-"-server-probe-readiness-path": /ready
-"-max-duration-seconds": 90
-"-target-readiness-timeout-seconds": 60
-"-http-requests": someRequest
-"-http-requests": anotherRequest
-```
-
-With these configs the mittens container will start to call _/ready_.
-Let's say that your application takes 30 seconds to start (ie, for _/ready_ to start returning 200).
-What happens is that after these initial 30 seconds, the warmup will start but unlike the previous example, this time it will run for a full 90 seconds.
-Note that during the warmup _someRequest_ and _anotherRequest_ will be called randomly and not in any particular order.
-
-If the application is not ready after the defined 60 seconds, we skip the warmup routine.


### PR DESCRIPTION
### :pencil: Description
Drops support for `target-readiness-timeout-seconds`.

### :link: Related Issues
#59