### PR TITLE
[#74] Enable updates of GitHub Actions using Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     interval: monthly
     time: "13:00"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "13:00"


### PR DESCRIPTION
### :pencil: Description
Enables GitHub Actions updates using Dependabot.

### :link: Related Issues
#74