### PR TITLE
Improve how to run doc when using docker locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To run the container:
 
     docker run mittens:latest -target-readiness-http-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:"{\"foo\":\"bar\",\"bar\":\"foo\"}"
 
-_Note_: If you use Docker for Mac you might need to set the target host (`target-http-host`, `target-grpc-host`) to `docker.for.mac.localhost`, or `docker.for.mac.host.internal`, or `host.docker.internal` (depending on your version of Docker) so that your container can resolve localhost.
+_Note_: If you use Docker for Mac/Windows you might need to set the target host (`target-http-host`, `target-grpc-host`) to `http://host.docker.internal` so that your container can resolve localhost. If you use an older version of Docker (< 18.03), the value will depend on your Operating System, e.g. `http://docker.for.mac.host.internal` or `http://docker.for.win.host.internal`.
 
 ## Contributing
 

--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -29,7 +29,7 @@ You can run the binary executable as follows:
           - app
         command: "-target-readiness-http-path=/health -target-grpc-port=6565 -max-duration-seconds=60 -concurrency=3 -http-requests=get:/hotel/potatoes -grpc-requests=service/method:{\"foo\":\"bar\", \"bar\":\"foo\"}"
 
-_Note_: If you use Docker for Mac you might need to set the target host (`target-http-host`, `target-grpc-host`) to `docker.for.mac.localhost`, or `docker.for.mac.host.internal`, or `host.docker.internal` (depending on your version of Docker) so that your container can resolve localhost.
+_Note_: If you use Docker for Mac/Windows you might need to set the target host (`target-http-host`, `target-grpc-host`) to `http://host.docker.internal` so that your container can resolve localhost. If you use an older version of Docker (< 18.03), the value will depend on your Operating System, e.g. `http://docker.for.mac.host.internal` or `http://docker.for.win.host.internal`.
 
 ## Run as a sidecar on Kubernetes
 


### PR DESCRIPTION
### :pencil: Description

Improve how to run docs when using docker locally:

- Do not mention only Mac
- Add http prefix so it's clearer what value to use
- Make `host.docker.internal` the first choice
- Remove deprecated values `docker.for.xxx.localhost`