### PR TITLE
[#89][#90] Fix grpc client. Add integration tests for grpc.

### DIFF
--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -17,7 +17,6 @@ package flags
 import (
 	"flag"
 	"fmt"
-	"log"
 	"math/rand"
 	"mittens/pkg/grpc"
 	"mittens/pkg/http"
@@ -75,7 +74,7 @@ func (r *Root) GetReadinessHTTPClient() http.Client {
 
 // GetReadinessGrpcClient creates the gRPC client to be used for the readiness requests.
 func (r *Root) GetReadinessGrpcClient() grpc.Client {
-	return r.Target.getReadinessGrpcClient()
+	return r.Target.getReadinessGrpcClient(r.MaxDurationSeconds)
 }
 
 // GetHTTPClient creates the HTTP client to be used for the actual requests.
@@ -116,7 +115,6 @@ func (r *Root) GetWarmupHTTPRequests() (chan http.Request, error) {
 	// create a goroutine that continuously adds requests to a channel for a maximum of MaxDurationSeconds
 	go func() {
 		if len(requests) == 0 {
-			log.Print("No http warm up requests specified")
 			close(requestsChan)
 			return
 		}
@@ -136,7 +134,7 @@ func (r *Root) GetWarmupHTTPRequests() (chan http.Request, error) {
 	return requestsChan, nil
 }
 
-// GetWarmupGrpcRequests returns a channel with gRPC requests.
+// getWarmupGrpcRequests returns a channel with gRPC requests.
 func (r *Root) GetWarmupGrpcRequests() (chan grpc.Request, error) {
 	requests, err := r.Grpc.getWarmupGrpcRequests()
 	if err != nil {
@@ -148,7 +146,6 @@ func (r *Root) GetWarmupGrpcRequests() (chan grpc.Request, error) {
 	// create a goroutine that continuously adds requests to a channel for a maximum of MaxDurationSeconds
 	go func() {
 		if len(requests) == 0 {
-			log.Print("No gRPC warm up requests specified")
 			close(requestsChan)
 			return
 		}

--- a/cmd/flags/target.go
+++ b/cmd/flags/target.go
@@ -24,16 +24,15 @@ import (
 
 // Target stores flags related to the target.
 type Target struct {
-	HTTPHost                string
-	HTTPPort                int
-	GrpcHost                string
-	GrpcPort                int
-	ReadinessProtocol       string
-	ReadinessHTTPPath       string
-	ReadinessGrpcMethod     string
-	ReadinessPort           int
-	ReadinessTimeoutSeconds int
-	Insecure                bool
+	HTTPHost            string
+	HTTPPort            int
+	GrpcHost            string
+	GrpcPort            int
+	ReadinessProtocol   string
+	ReadinessHTTPPath   string
+	ReadinessGrpcMethod string
+	ReadinessPort       int
+	Insecure            bool
 }
 
 func (t *Target) String() string {
@@ -62,11 +61,10 @@ func toIntOrDefaultIfNull(value *int, defaultValue int) int {
 func (t *Target) getWarmupTargetOptions() warmup.TargetOptions {
 
 	return warmup.TargetOptions{
-		ReadinessProtocol:         t.ReadinessProtocol,
-		ReadinessHTTPPath:         t.ReadinessHTTPPath,
-		ReadinessGrpcMethod:       t.ReadinessGrpcMethod,
-		ReadinessPort:             t.ReadinessPort,
-		ReadinessTimeoutInSeconds: t.ReadinessTimeoutSeconds,
+		ReadinessProtocol:   t.ReadinessProtocol,
+		ReadinessHTTPPath:   t.ReadinessHTTPPath,
+		ReadinessGrpcMethod: t.ReadinessGrpcMethod,
+		ReadinessPort:       t.ReadinessPort,
 	}
 }
 
@@ -74,8 +72,8 @@ func (t *Target) getReadinessHTTPClient() http.Client {
 	return http.NewClient(fmt.Sprintf("%s:%d", t.HTTPHost, t.ReadinessPort), t.Insecure)
 }
 
-func (t *Target) getReadinessGrpcClient() grpc.Client {
-	return grpc.NewClient(fmt.Sprintf("%s:%d", t.GrpcHost, t.ReadinessPort), t.Insecure, t.ReadinessTimeoutSeconds)
+func (t *Target) getReadinessGrpcClient(timeoutSeconds int) grpc.Client {
+	return grpc.NewClient(fmt.Sprintf("%s:%d", t.GrpcHost, t.ReadinessPort), t.Insecure, timeoutSeconds)
 }
 
 func (t *Target) getHTTPClient() http.Client {

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -41,7 +41,6 @@ func NewClient(host string, insecure bool) Client {
 	}
 
 	if insecure {
-		log.Printf("HTTP client: insecure")
 		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}


### PR DESCRIPTION
### :pencil: Description
- Fixes issue where mittens wouldn't establish connection to the gRPC server. This would cause a panic error (#89).
- Adds logic to avoid spinning up the corresponding goroutines for HTTP and gRPC if there are no requests of that type.
- Adds integration tests for gRPC (#90).
- Fixes the gRPC readiness functionality. The timeout for that would be 0 since we were relying on the removed `-target-readiness-timeout-seconds`. 

### :link: Related Issues
#89 #90