### PR TITLE
Format dates

### DIFF
--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -62,7 +62,7 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- `{$currentDate|days+x,months+y,years+z}`: you can adjust the temporal offset by adding or subtracting days, months, or years. The offsets are optional and can be removed.
+- `{$currentDate|days+x,months+y,years+z,format=yyyy-MM-dd}`: you can adjust the temporal offset by adding or subtracting days, months, or years. Make sure you use the same order for each of the modifiers (ie, days must be left of months). You can optionally specify a custom format using yyyy or yy to represent the year, MM or MMM for the month and dd or d for the day.
 - `{$currentTimestamp}`: Time from Unix epoch in milliseconds.
 - `{$random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - `{$range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -62,7 +62,7 @@ optional). Host and port are taken from `target-grpc-host` and
 
 Mittens allows you to use special keywords if you need to generate randomized urls.
 The following are available:
-- `{$currentDate|days+x,months+y,years+z,format=yyyy-MM-dd}`: you can adjust the temporal offset by adding or subtracting days, months, or years. Make sure you use the same order for each of the modifiers (ie, days must be left of months). You can optionally specify a custom format using yyyy or yy to represent the year, MM or MMM for the month and dd or d for the day.
+- `{$currentDate|days+x,months+y,years+z,format=yyyy-MM-dd}`: you can adjust the temporal offset by adding or subtracting days, months, or years. The offsets are optional and can be removed, but their order cannot change (i.e. `days` is always first, or `years` always last). You can optionally specify a custom format using yyyy or yy to represent the year, MM or MMM for the month and dd or d for the day.
 - `{$currentTimestamp}`: Time from Unix epoch in milliseconds.
 - `{$random|foo,bar,baz}`: Mittens will randomly select an element from the provided list, eg: one of foo, bar or baz. Special chars are not supported. Valid: [0-9A-Za-z_]
 - `{$range|min=x,max=y}`: both min and max are required arguments. Range is inclusive.

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -101,7 +101,7 @@ func dateElements(source string) string {
 	offsetYears, _ := strconv.Atoi(years)
 
 	if format == "" {
-		// If no format override is specifie, we default to ISO 8601, or YYYY MM DD
+		// If no format override is specified, we default to ISO 8601, or YYYY MM DD
 		format = "2006-01-02"
 	} else {
 		format = strings.ReplaceAll(format, "yyyy", "2006")

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -47,8 +47,9 @@ var allowedHTTPMethods = map[string]interface{}{
 var templatePlaceholderRegex = regexp.MustCompile("{\\$(\\w+(?:[\\|(?:[\\w+-=,]+)]*)}")
 var templateRangeRegex = regexp.MustCompile("{\\$range\\|min=(?P<Min>\\d+),max=(?P<Max>\\d+)}")
 var templateElementsRegex = regexp.MustCompile("{\\$random\\|(?P<Elements>[,\\w-]+)}")
-var templateDatesRegex = regexp.MustCompile("{\\$currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*)*}")
+var templateDatesRegex = regexp.MustCompile("{\\$currentDate(?:\\|(?:days(?P<Days>[+-]\\d+))*(?:[,]*months(?P<Months>[+-]\\d+))*(?:[,]*years(?P<Years>[+-]\\d+))*(?:[,]*format=(?P<Format>[yMd|,/-]+))*)*}")
 
+//
 // ToHTTPRequest parses an HTTP request which is in a string format and stores it in a struct.
 func ToHTTPRequest(requestString string) (Request, error) {
 	parts := strings.SplitN(requestString, ":", 3)
@@ -93,13 +94,26 @@ func dateElements(source string) string {
 	days := r[1]
 	months := r[2]
 	years := r[3]
+	format := r[4]
 
 	offsetDays, _ := strconv.Atoi(days)
 	offsetMonths, _ := strconv.Atoi(months)
 	offsetYears, _ := strconv.Atoi(years)
 
+	if format == "" {
+		// If no format override is specifie, we default to ISO 8601, or YYYY MM DD
+		format = "2006-01-02"
+	} else {
+		format = strings.ReplaceAll(format, "yyyy", "2006")
+		format = strings.ReplaceAll(format, "yy", "06")
+		format = strings.ReplaceAll(format, "MMM", "Jan")
+		format = strings.ReplaceAll(format, "MM", "01")
+		format = strings.ReplaceAll(format, "dd", "02")
+		format = strings.ReplaceAll(format, "d", "2")
+	}
+
 	// the date below is how the golang date formatter works. it's used for the formatting. it's not what is actually going to be displayed
-	return time.Now().AddDate(offsetYears, offsetMonths, offsetDays).Format("2006-01-02")
+	return time.Now().AddDate(offsetYears, offsetMonths, offsetDays).Format(format)
 }
 
 // timestampElements returns the current time from Unix epoch in milliseconds.

--- a/pkg/http/utils_test.go
+++ b/pkg/http/utils_test.go
@@ -46,12 +46,12 @@ func TestHttp_FlagWithoutBodyToHttpRequest(t *testing.T) {
 }
 
 func TestHttp_DateInterpolation(t *testing.T) {
-	requestFlag := `post:/db_{$currentDate}:{"date": "{$currentDate|days+5,months+2,years-1}"}`
+	requestFlag := `post:/db_{$currentDate}:{"date": "{$currentDate|days+5,months+2,years-1,format=yyyy-MM-dd}"}`
 	request, err := ToHTTPRequest(requestFlag)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, request.Method)
-	dateToday := time.Now().Format("2006-01-02")                        // today + 5
+	dateToday := time.Now().Format("2006-01-02")                        // today
 	dateWithOffset := time.Now().AddDate(-1, 2, 5).Format("2006-01-02") // today -1 year, +2 months, +5 days
 	assert.Equal(t, "/db_"+dateToday, request.Path)
 	assert.Equal(t, fmt.Sprintf(`{"date": "%s"}`, dateWithOffset), *request.Body)


### PR DESCRIPTION
### :pencil: Description
Fixes #92

`{$currentDate|days+x,months+y,years+z,format=yyyy-MM-dd}`: you can adjust the temporal offset by adding or subtracting days, months, or years. Make sure you use the same order for each of the modifiers (ie, days must be left of months). **You can optionally specify a custom format using yyyy or yy to represent the year, MM or MMM for the month and dd or d for the day.**