### PR TITLE
Use scratch as base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /mittens
 # Run unit tests & build app
 RUN make unit-tests
 
-FROM alpine:3.7
+FROM scratch
 COPY --from=0 /mittens/mittens /app/mittens
 ENTRYPOINT ["/app/mittens"]


### PR DESCRIPTION
### :pencil: Description
Use scratch as base docker image
