### PR TITLE
Use alpine. scratch doesn't come with cat.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /mittens
 # Run unit tests & build app
 RUN make unit-tests
 
-FROM scratch
+FROM alpine:3.7
 COPY --from=0 /mittens/mittens /app/mittens
 ENTRYPOINT ["/app/mittens"]


### PR DESCRIPTION
### :pencil: Description
I completely missed that we need cat in the mittens image for the readiness/liveness check.
And scratch doesn't come with it. Reverting back to alpine.

### :link: Related Issues