### PR TITLE
Add more structure to response logging

### DIFF
--- a/pkg/warmup/warmup.go
+++ b/pkg/warmup/warmup.go
@@ -86,9 +86,9 @@ func (w Warmup) HTTPWarmupWorker(wg *sync.WaitGroup, requests <-chan http.Reques
 			*requestsSentCounter++
 
 			if resp.StatusCode/100 == 2 {
-				log.Printf("%s response for %s %d ms: %v", resp.Type, request.Path, resp.Duration/time.Millisecond, resp.StatusCode)
+				log.Printf("🟢 %s response\t%d ms\t%v\t%s\t%s", resp.Type, resp.Duration/time.Millisecond, resp.StatusCode, request.Method, request.Path)
 			} else {
-				log.Printf("🔴 %s response for %s %d ms: %v", resp.Type, request.Path, resp.Duration/time.Millisecond, resp.StatusCode)
+				log.Printf("🔴 %s response\t%d ms\t%v\t%s\t%s", resp.Type, resp.Duration/time.Millisecond, resp.StatusCode, request.Method, request.Path)
 			}
 		}
 	}
@@ -107,7 +107,7 @@ func (w Warmup) GrpcWarmupWorker(wg *sync.WaitGroup, requests <-chan grpc.Reques
 		} else {
 			*requestsSentCounter++
 
-			log.Printf("%s response for %s %d ms", resp.Type, request.ServiceMethod, resp.Duration/time.Millisecond)
+			log.Printf("🟢 %s response\t%d ms %s", resp.Type, resp.Duration/time.Millisecond, request.ServiceMethod)
 		}
 
 	}


### PR DESCRIPTION
### :pencil: Description

Adds more readable logging outputs _**for HTTP and gRPC**_.

### :link: Related Issues

#148

### test results

```shell
~/repos/mittens 20s ❯ make -B unit-tests    
go: downloading github.com/jhump/protoreflect v1.8.2
go: downloading google.golang.org/grpc v1.36.0
go: downloading github.com/fullstorydev/grpcurl v1.8.0
go: downloading github.com/stretchr/testify v1.7.0
?       mittens [no test files]
?       mittens/cmd     [no test files]
ok      mittens/cmd/flags       0.266s
?       mittens/fixture [no test files]
ok      mittens/pkg/grpc        0.230s
ok      mittens/pkg/http        0.210s
ok      mittens/pkg/placeholders        0.584s
?       mittens/pkg/probe       [no test files]
?       mittens/pkg/response    [no test files]
ok      mittens/pkg/safe        0.307s
ok      mittens/pkg/util        0.459s
?       mittens/pkg/warmup      [no test files]
```

outputs:
```shell

2021/03/04 20:56:01 💚 Target is ready
2021/03/04 20:56:01 gRPC client connecting...
2021/03/04 20:56:01 gRPC client connected
2021/03/04 20:56:01 Spawning new go routine for gRPC requests
2021/03/04 20:56:01 Spawning new go routine for gRPC requests
2021/03/04 20:56:01 Spawning new go routine for HTTP requests
2021/03/04 20:56:01 Spawning new go routine for HTTP requests
2021/03/04 20:56:01 🟢 grpc response	4 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:01 🟢 grpc response	4 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:02 🟢 http response	101 ms	204	GET	/delay
2021/03/04 20:56:02 🟢 http response	102 ms	204	GET	/delay
2021/03/04 20:56:02 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:02 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:02 🟢 http response	101 ms	204	GET	/delay
2021/03/04 20:56:02 🟢 http response	101 ms	204	GET	/delay
2021/03/04 20:56:02 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:02 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:03 🟢 http response	101 ms	204	GET	/delay
2021/03/04 20:56:03 🟢 http response	101 ms	204	GET	/delay
2021/03/04 20:56:03 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:03 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:03 🟢 http response	104 ms	204	GET	/delay
2021/03/04 20:56:03 🟢 http response	104 ms	204	GET	/delay
2021/03/04 20:56:03 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:03 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:04 🟢 http response	103 ms	204	GET	/delay
2021/03/04 20:56:04 🟢 http response	103 ms	204	GET	/delay
2021/03/04 20:56:04 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:04 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:04 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:04 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:05 🟢 http response	104 ms	204	GET	/delay
2021/03/04 20:56:05 🟢 http response	104 ms	204	GET	/delay
2021/03/04 20:56:05 🟢 grpc response	0 ms grpc.testing.TestService/EmptyCall
2021/03/04 20:56:05 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:05 🟢 http response	100 ms	204	GET	/delay
2021/03/04 20:56:05 🟢 http response	100 ms	204	GET	/delay
2021/03/04 20:56:05 🟢 grpc response	0 ms grpc.testing.TestService/UnaryCall
2021/03/04 20:56:06 🟢 http response	103 ms	204	GET	/delay
2021/03/04 20:56:06 Warm up finished 😊 Approximately 32 reqs were sent
2021/03/04 20:56:06 Writing file: ready
2021/03/04 20:56:06 Wrote file: ready
--- PASS: TestGrpcAndHttp (5.85s)
```
AND another example
```shell
2021/03/04 20:26:09 Waiting for http target to be ready for a max of 60s
2021/03/04 20:26:10 💚 Target is ready
2021/03/04 20:26:10 Spawning new go routine for HTTP requests
2021/03/04 20:26:10 🟢 http response    260 ms  200     DELETE  /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:10 🟢 http response    118 ms  200     POST    /accounts
2021/03/04 20:26:11 🟢 http response    129 ms  200     POST    /accounts
2021/03/04 20:26:14 🟢 http response    82 ms   200     GET     /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:14 🟢 http response    70 ms   200     GET     /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:14 🟢 http response    68 ms   200     GET     /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:14 🟢 http response    107 ms  200     POST    /accounts
2021/03/04 20:26:15 🟢 http response    74 ms   200     GET     /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:15 🟢 http response    188 ms  200     DELETE  /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:15 🔴 http response    53 ms   403     GET     /accounts/afa0fb3f-4814-4895-9ec9-1a483548f4d5
2021/03/04 20:26:15 🟢 http response    105 ms  200     POST    /accounts
..
```