### PR TITLE
fix: change no effect code to log.Printf

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"mittens/cmd/flags"
 	"mittens/pkg/probe"
@@ -52,17 +51,17 @@ func run() int {
 	var validationError bool
 	httpRequests, err := opts.GetWarmupHTTPRequests()
 	if err != nil {
-		fmt.Errorf("invalid HTTP options: %v", err)
+		log.Printf("invalid HTTP options: %v", err)
 		validationError = true
 	}
 	grpcRequests, err := opts.GetWarmupGrpcRequests()
 	if err != nil {
-		fmt.Errorf("invalid grpc options: %v", err)
+		log.Printf("invalid grpc options: %v", err)
 		validationError = true
 	}
 	targetOptions, err := opts.GetWarmupTargetOptions()
 	if err != nil {
-		fmt.Errorf("invalid target options: %v", err)
+		log.Printf("invalid target options: %v", err)
 		validationError = true
 	}
 


### PR DESCRIPTION
- fmt.Errorf is not a function to print error. it make and return error.
- run() function does return no error, so change to print error using
  log.Printf

<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
In run() function, some errors made by fmt.Errors are not used. 
run() funcions does not return error, so errors should print using log.Printf if it need.

### :link: Related Issues

N/A