### PR TITLE
Downgrade builder docker image to go 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.14
 # Create required dirs and copy files
 RUN mkdir -p /mittens
 COPY ./ /mittens/


### PR DESCRIPTION
### :pencil: Description
For some reason tests are failing with 16. Downgrading temporarily to 14 until we figure out what's wrong.
