### PR TITLE
Pass headers in health check too

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,7 @@ func run() int {
 	requestsSentCounter := 0
 	if !validationError {
 		target := createTarget(targetOptions)
-		if err := target.WaitForReadinessProbe(); err == nil {
+		if err := target.WaitForReadinessProbe(opts.GetWarmupHTTPHeaders()); err == nil {
 			log.Print("💚 Target is ready")
 
 			wp := warmup.Warmup{


### PR DESCRIPTION
### :pencil: Description
The headers were passed only in warmup calls and not health check calls, it lead to problems if there was a need to pass client info in headers grpc reflections calls or even health checks.

Let me know if you think its not valid case to pass request headers.

### :link: Related Issues