### PR TITLE
Added ramp up

### DIFF
--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -37,6 +37,7 @@ type Root struct {
 	HTTP
 	HTTPHeaders
 	Grpc
+	RampUpIntervalSeconds int
 }
 
 func (r *Root) String() string {
@@ -50,6 +51,7 @@ func (r *Root) InitFlags() {
 	flag.IntVar(&r.RequestDelayMilliseconds, "request-delay-milliseconds", 500, "Delay in milliseconds between requests")
 	flag.BoolVar(&r.ExitAfterWarmup, "exit-after-warmup", false, "If warm up process should finish after completion. This is useful to prevent container restarts.")
 	flag.BoolVar(&r.FailReadiness, "fail-readiness", false, "If set to true readiness will fail if no requests were sent.")
+	flag.IntVar(&r.RampUpIntervalSeconds, "ramp-up-interval-seconds", 0, "If set to non negative number, ramps up by with this interval")
 
 	r.FileProbe.initFlags()
 	r.Target.initFlags()
@@ -66,6 +68,11 @@ func (r *Root) GetMaxDurationSeconds() int {
 // GetConcurrency returns the value of the concurrency parameter.
 func (r *Root) GetConcurrency() int {
 	return r.Concurrency
+}
+
+// GetRampUpIntervalSeconds returns the value of the ramp-up-interval-seconds parameter.
+func (r *Root) GetRampUpIntervalSeconds() int {
+	return r.RampUpIntervalSeconds
 }
 
 // GetReadinessHTTPClient creates the HTTP client to be used for the readiness requests.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ func run() int {
 				GrpcRequests:             grpcRequests,
 				HttpHeaders:              opts.GetWarmupHTTPHeaders(),
 				RequestDelayMilliseconds: opts.RequestDelayMilliseconds,
+				RampUpIntervalSeconds:    opts.RampUpIntervalSeconds,
 			}
 			wp.Run(hasHttpRequests, hasGrpcRequests, &requestsSentCounter)
 		} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,7 @@ func run() int {
 				RequestDelayMilliseconds: opts.RequestDelayMilliseconds,
 				RampUpIntervalSeconds:    opts.RampUpIntervalSeconds,
 			}
-			wp.Run(hasHttpRequests, hasGrpcRequests, &requestsSentCounter)
+			wp.Run(hasHttpRequests, hasGrpcRequests, &requestsSentCounter, opts.MaxDurationSeconds)
 		} else {
 			log.Print("Target still not ready. Giving up!")
 		}

--- a/internal/pkg/warmup/warmup.go
+++ b/internal/pkg/warmup/warmup.go
@@ -119,11 +119,12 @@ func (w Warmup) GrpcWarmupWorker(wg *sync.WaitGroup, requests <-chan grpc.Reques
 	wg.Done()
 }
 
+// checks if ramp up is enabled, sleep not required for concurrency 1, sleep may not be required for last few ramp ups (when unbalanced interval)
 func waitForRampUp(rampUpIntervalSeconds int, currentConcurrency int, endTime time.Time) bool {
 	var sleepInterval = math.Ceil(time.Until(endTime).Seconds())
 
 	if rampUpIntervalSeconds > 0 && currentConcurrency > 1 && sleepInterval > 0 {
 		time.Sleep(time.Duration(math.Min(float64(rampUpIntervalSeconds), sleepInterval)) * time.Second)
 	}
-	return sleepInterval > 0
+	return sleepInterval > 0 // Need not ramp up if maxDuration is exhausted
 }

--- a/internal/pkg/warmup/warmup.go
+++ b/internal/pkg/warmup/warmup.go
@@ -119,6 +119,5 @@ func (w Warmup) GrpcWarmupWorker(wg *sync.WaitGroup, requests <-chan grpc.Reques
 func delayIfNeeded(rampUpIntervalSeconds int, currentConcurrency int) {
 	if rampUpIntervalSeconds > 0 && currentConcurrency > 1 {
 		time.Sleep(time.Duration(rampUpIntervalSeconds) * time.Second)
-		log.Printf("Ramping up concurrency")
 	}
 }

--- a/internal/pkg/warmup/warmup.go
+++ b/internal/pkg/warmup/warmup.go
@@ -109,7 +109,7 @@ func (w Warmup) GrpcWarmupWorker(wg *sync.WaitGroup, requests <-chan grpc.Reques
 			log.Printf("🔴 Error in request for %s: %v", request.ServiceMethod, resp.Err)
 		} else {
 			*requestsSentCounter++
-			log.Printf("🟢 %s response\t%d ms\t%v\t%s", resp.Type, resp.Duration/time.Millisecond, resp.StatusCode, request.ServiceMethod)
+			log.Printf("🟢 %s response\t%d ms %s", resp.Type, resp.Duration/time.Millisecond, request.ServiceMethod)
 		}
 
 	}

--- a/test/root_test.go
+++ b/test/root_test.go
@@ -171,7 +171,8 @@ func TestGrpcAndHttp(t *testing.T) {
 		"-concurrency=2",
 		"-exit-after-warmup=true",
 		"-target-readiness-http-path=/health",
-		"-max-duration-seconds=2",
+		"-max-duration-seconds=3",
+		"-ramp-up-interval-seconds=1",
 	}
 
 	cmd.CreateConfig()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Attempt to add ramp up feature. Takes a new parameter ramp-up-interval-seconds and tries to increase concurrency by 1 every ramp-up-interval-seconds. Works well when ramp up duration=max duration/concurrency. If it's not, it adds time to overall warmup execution.

eg, if max duration is 60 seconds and ramp up is 20 seconds and concurrency is 3, it works well
if max duration is 60 seconds and ramp up is 55 seconds and concurrency is 2, it works well
but if max duration is 60 seconds and ramp up is 55 seconds and concurrency is 3, the program waits for extra duration even though the requests have stopped firing 50 seconds ago.

We can implement this in a different way by making this new param a bool to say ramp up or not and we can calculate the ramp up interval as max duration/concurrency.

### :link: Related Issues
https://github.com/ExpediaGroup/mittens/issues/199