### PR TITLE
Interpolate headers (use placeholders in http headers)

### DIFF
--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -54,7 +54,8 @@ optional). Host and port are taken from `target-grpc-host` and
 
 ### Placeholders for random elements
 
-Mittens allows you to use special keywords if you need to generate randomized urls.
+Mittens allows you to use special keywords if you need to make randomized requests. You can use these in the HTTP headers as well as in the request parameters and request bodies.
+
 The following are available:
 - `{$currentDate|days+x,months+y,years+z,format=yyyy-MM-dd}`: you can adjust the temporal offset by adding or subtracting days, months, or years. The offsets are optional and can be removed, but their order cannot change (i.e. `days` is always first, or `years` always last). You can optionally specify a custom format using yyyy or yy to represent the year, MM or MMM for the month and dd or d for the day.
 - `{$currentTimestamp}`: Time from Unix epoch in milliseconds.

--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"mittens/internal/pkg/placeholders"
 	"mittens/internal/pkg/response"
 	"os"
 	"time"
@@ -100,7 +101,14 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 
 	loggingEventHandler := eventHandler{InvocationEventHandler: delegate, logResponses: logResponses}
 	startTime := time.Now()
-	err = grpcurl.InvokeRPC(context.Background(), c.descriptorSource, c.conn, serviceMethod, headers, loggingEventHandler, requestParser.Next)
+
+	// Interpolate
+	interpolatedHeaders := make([]string, len(headers))
+	for i, header := range headers {
+		interpolatedHeaders[i] = placeholders.InterpolatePlaceholders(header)
+	}
+
+	err = grpcurl.InvokeRPC(context.Background(), c.descriptorSource, c.conn, serviceMethod, interpolatedHeaders, loggingEventHandler, requestParser.Next)
 	endTime := time.Now()
 	if err != nil {
 		log.Printf("grpc response error: %s", err)

--- a/internal/pkg/http/client_test.go
+++ b/internal/pkg/http/client_test.go
@@ -40,14 +40,14 @@ func TestMain(m *testing.M) {
 func TestRequestSuccess(t *testing.T) {
 	c := NewClient(serverUrl, false)
 	reqBody := ""
-	resp := c.SendRequest("GET", WorkingPath, map[string]string{}, &reqBody)
+	resp := c.SendRequest("GET", WorkingPath, []string{}, &reqBody)
 	assert.Nil(t, resp.Err)
 }
 
 func TestHttpError(t *testing.T) {
 	c := NewClient(serverUrl, false)
 	reqBody := ""
-	resp := c.SendRequest("GET", "/", map[string]string{}, &reqBody)
+	resp := c.SendRequest("GET", "/", []string{}, &reqBody)
 	assert.Nil(t, resp.Err)
 	assert.Equal(t, resp.StatusCode, 404)
 }
@@ -55,7 +55,7 @@ func TestHttpError(t *testing.T) {
 func TestConnectionError(t *testing.T) {
 	c := NewClient("http://localhost:9999", false)
 	reqBody := ""
-	resp := c.SendRequest("GET", "/potato", map[string]string{}, &reqBody)
+	resp := c.SendRequest("GET", "/potato", []string{}, &reqBody)
 	assert.NotNil(t, resp.Err)
 }
 

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -29,8 +29,8 @@ func ToHeaders(headersFlag []string) map[string]string {
 			log.Printf("cannot find ':' separator in supplied header %s", h)
 			headers[strings.TrimSpace(kv[0])] = ""
 			continue
-		}
-		headers[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}		
+		headers[strings.TrimSpace(kv[0])] = placeholders.InterpolatePlaceholders(strings.TrimSpace(kv[1]))
 	}
 	return headers
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -16,13 +16,11 @@ package util
 
 import (
 	"log"
-	"mittens/internal/pkg/placeholders"	
 	"strings"
 )
 
 // ToHeaders converts the headers from the format these are passed by the user to a map.
 func ToHeaders(headersFlag []string) map[string]string {
-
 	headers := make(map[string]string)
 	for _, h := range headersFlag {
 		kv := strings.SplitN(h, ":", 2)
@@ -31,7 +29,7 @@ func ToHeaders(headersFlag []string) map[string]string {
 			headers[strings.TrimSpace(kv[0])] = ""
 			continue
 		}
-		headers[strings.TrimSpace(kv[0])] = placeholders.InterpolatePlaceholders(strings.TrimSpace(kv[1]))
+		headers[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
 	}
 	return headers
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -29,7 +29,7 @@ func ToHeaders(headersFlag []string) map[string]string {
 			log.Printf("cannot find ':' separator in supplied header %s", h)
 			headers[strings.TrimSpace(kv[0])] = ""
 			continue
-		}		
+		}
 		headers[strings.TrimSpace(kv[0])] = placeholders.InterpolatePlaceholders(strings.TrimSpace(kv[1]))
 	}
 	return headers

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"log"
+	"mittens/internal/pkg/placeholders"	
 	"strings"
 )
 

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -59,15 +59,3 @@ func Test_HeadersWithMultipleSeparatorsToHeaders(t *testing.T) {
 	assert.Equal(t, 1, len(headers))
 	assert.Equal(t, "some:strange:cookie", headers["Cookie"])
 }
-
-func Test_HeadersWithMultipleSeparatorsToHeadersWithPlaceholders(t *testing.T) {
-
-	headersFlag := []string{
-		"Cookie: {$random|foo}",
-	}
-
-	headers := ToHeaders(headersFlag)
-
-	assert.Equal(t, 1, len(headers))
-	assert.Equal(t, "foo", headers["Cookie"])
-}

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -59,3 +59,15 @@ func Test_HeadersWithMultipleSeparatorsToHeaders(t *testing.T) {
 	assert.Equal(t, 1, len(headers))
 	assert.Equal(t, "some:strange:cookie", headers["Cookie"])
 }
+
+func Test_HeadersWithMultipleSeparatorsToHeadersWithPlaceholders(t *testing.T) {
+
+	headersFlag := []string{
+		"Cookie: {$random|foo}",
+	}
+
+	headers := ToHeaders(headersFlag)
+
+	assert.Equal(t, 1, len(headers))
+	assert.Equal(t, "foo", headers["Cookie"])
+}

--- a/internal/pkg/warmup/target.go
+++ b/internal/pkg/warmup/target.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"mittens/internal/pkg/grpc"
 	whttp "mittens/internal/pkg/http"
-	"mittens/internal/pkg/util"
 	"net/http"
 	"time"
 )
@@ -72,7 +71,7 @@ func (t Target) WaitForReadinessProbe(headers []string) error {
 
 			if t.options.ReadinessProtocol == "http" {
 				// error if error in the response or status code not in the 200 range
-				if resp := t.readinessHTTPClient.SendRequest(http.MethodGet, t.options.ReadinessHTTPPath, util.ToHeaders(headers), nil); resp.Err != nil || resp.StatusCode/100 != 2 {
+				if resp := t.readinessHTTPClient.SendRequest(http.MethodGet, t.options.ReadinessHTTPPath, headers, nil); resp.Err != nil || resp.StatusCode/100 != 2 {
 					log.Printf("HTTP target not ready yet...")
 					continue
 				}

--- a/internal/pkg/warmup/warmup.go
+++ b/internal/pkg/warmup/warmup.go
@@ -20,7 +20,7 @@ import (
 	"mittens/internal/pkg/grpc"
 	"mittens/internal/pkg/http"
 	"mittens/internal/pkg/safe"
-	"mittens/internal/pkg/util"
+
 	"sync"
 	"time"
 )
@@ -69,7 +69,7 @@ func (w Warmup) Run(hasHttpRequests bool, hasGrpcRequests bool, requestsSentCoun
 			log.Printf("Spawning new go routine for HTTP requests")
 			wg.Add(1)
 			go safe.Do(func() {
-				w.HTTPWarmupWorker(&wg, w.HttpRequests, util.ToHeaders(w.HttpHeaders), w.RequestDelayMilliseconds, requestsSentCounter)
+				w.HTTPWarmupWorker(&wg, w.HttpRequests, w.HttpHeaders, w.RequestDelayMilliseconds, requestsSentCounter)
 			})
 		}
 	}
@@ -78,7 +78,7 @@ func (w Warmup) Run(hasHttpRequests bool, hasGrpcRequests bool, requestsSentCoun
 }
 
 // HTTPWarmupWorker sends HTTP requests to the target using goroutines.
-func (w Warmup) HTTPWarmupWorker(wg *sync.WaitGroup, requests <-chan http.Request, headers map[string]string, requestDelayMilliseconds int, requestsSentCounter *int) {
+func (w Warmup) HTTPWarmupWorker(wg *sync.WaitGroup, requests <-chan http.Request, headers []string, requestDelayMilliseconds int, requestsSentCounter *int) {
 	for request := range requests {
 		time.Sleep(time.Duration(requestDelayMilliseconds) * time.Millisecond)
 


### PR DESCRIPTION
Http headers sent during warmup phase would allow placeholders replacement (every line of sent http headers would go thru InterpolatePlaceholders())

https://github.com/ExpediaGroup/mittens/issues/204