### PR TITLE
Fix deprecated usage of withInsecure

### DIFF
--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
@@ -62,7 +63,7 @@ func (c *Client) Connect(headers []string) error {
 
 	dialOptions := []grpc.DialOption{grpc.WithBlock()}
 	if c.insecure {
-		dialOptions = append(dialOptions, grpc.WithInsecure())
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	conn, err := grpc.DialContext(ctx, c.host, dialOptions...)


### PR DESCRIPTION
### :pencil: Description
- `grpc.WithInsecure` is deprecated. Replacing with `withTransportCredentials`
