### PR TITLE
Ignore certificate in insecure mode

### DIFF
--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
@@ -63,7 +63,12 @@ func (c *Client) Connect(headers []string) error {
 
 	dialOptions := []grpc.DialOption{grpc.WithBlock()}
 	if c.insecure {
-		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		tlsConf, err := grpcurl.ClientTLSConfig(c.insecure, "", "", "")
+		if err != nil {
+			return fmt.Errorf("failed to create TLS config: %v", err)
+		}
+		var creds = credentials.NewTLS(tlsConf)
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(creds))
 	}
 
 	conn, err := grpc.DialContext(ctx, c.host, dialOptions...)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

Currently insecure mode is not working with tls connection properly.
Added support for ignoring certificate similar to how http warmup behaves.

### :link: Related Issues

[#249](https://github.com/ExpediaGroup/mittens/issues/249)