### PR TITLE
Docs(Updates Instructions): Adds note about required endpoints for HTTP and gRPC requests

### DIFF
--- a/docs/installation/running.md
+++ b/docs/installation/running.md
@@ -6,6 +6,8 @@ title: How to Run
 The simplest way to run Mittens is as a cmd application. It receives a number of command line arguments (see [flags](https://expediagroup.github.io/mittens/docs/about/getting-started#flags)).
 You can also run it as a linked Docker container or even as a sidecar in Kubernetes.
 
+> Please ensure that your service provides endpoints for both HTTP and gRPC requests, with the HTTP endpoint being exposed at `/hotel/potatoes` and the gRPC endpoint at `service/method` before running the below commands.
+
 ## Run as a cmd application
 
 You can run the binary executable as follows:
@@ -148,7 +150,7 @@ spec:
         volumeMounts:
           - name: mittens-config
             mountPath: /mittens
-    volumes:
+      volumes:
         - name: mittens-config
           configMap:
             name: mittens-config


### PR DESCRIPTION
### :pencil: Description
- Added a note to the documentation about the required endpoints for HTTP and gRPC requests when using mittens
- Clarified that the HTTP endpoint should be exposed at `/hotel/potatoes` and the gRPC endpoint at `service/method`
- Aimed to make the instructions more explicit and easier to follow for users who are new to mittens
- No code changes were made, only documentation updates

### :computer: Screenshots
<img width="774" alt="Mittens" src="https://user-images.githubusercontent.com/14826718/231251471-d131f627-79d5-4538-afa6-f1394de233a8.png">