### PR TITLE
fix: null pointer when connection not available

### DIFF
--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -122,6 +122,11 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 		interpolatedHeaders[i] = placeholders.InterpolatePlaceholders(header)
 	}
 
+	if c.conn == nil {
+		log.Printf("No connection available. Skip making request.")
+		return response.Response{Duration: time.Duration(0), Err: err, Type: respType}
+	}
+
 	err = grpcurl.InvokeRPC(context.Background(), c.descriptorSource, c.conn, serviceMethod, interpolatedHeaders, loggingEventHandler, requestParser.Next)
 	endTime := time.Now()
 	if err != nil {

--- a/internal/pkg/warmup/target.go
+++ b/internal/pkg/warmup/target.go
@@ -81,6 +81,7 @@ func (t Target) WaitForReadinessProbe(maxReadinessWaitDurationInSeconds int, hea
 					connErr := t.readinessGrpcClient.Connect(nil)
 					if connErr != nil {
 						log.Printf("gRPC readiness client connect error: %v", connErr)
+						continue
 					}
 					err1 := t.readinessGrpcClient.SendRequest(request.ServiceMethod, "", headers, false)
 					if err1.Err != nil {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

If grpc connection is not obtained even after timeout, previously that led to null pointer and a threw a panic

> $ ./mittens -target-grpc-timeout-milliseconds 100 -target-readiness-protocol=grpc -exit-after-warmup
2023/06/12 23:37:48 Writing file: alive
2023/06/12 23:37:48 Wrote file: alive
2023/06/12 23:37:48 []
2023/06/12 23:37:48 Waiting for grpc target to be ready for a max of 30s
2023/06/12 23:37:49 gRPC readiness client connecting...
2023/06/12 23:37:49 using gRPC server SSL/TLS authentication
2023/06/12 23:37:49 gRPC readiness client connect error: gRPC dial: context deadline exceeded: connection error: desc = "transport: Error while dialing: dial tcp [::1]:8080: connect: connection refused"
2023/06/12 23:37:49 Unexpected panic was caught: runtime error: invalid memory address or nil pointer dereference

Also, connection failed, retry would not happen. Now both are fixed
> $ ./mittens -target-grpc-timeout-milliseconds 1000 -max-readiness-wait-seconds=3 -target-readiness-protocol=grpc -exit-after-warmup 
2023/06/12 23:41:52 Writing file: alive
2023/06/12 23:41:52 Wrote file: alive
2023/06/12 23:41:52 []
2023/06/12 23:41:52 Waiting for grpc target to be ready for a max of 3s
2023/06/12 23:41:53 gRPC readiness client connecting...
2023/06/12 23:41:53 using gRPC server SSL/TLS authentication
2023/06/12 23:41:54 gRPC readiness client connect error: gRPC dial: context deadline exceeded: connection error: desc = "transport: Error while dialing: dial tcp [::1]:8080: connect: connection refused"
2023/06/12 23:41:55 gRPC readiness client connecting...
2023/06/12 23:41:55 using gRPC server SSL/TLS authentication
2023/06/12 23:41:56 gRPC readiness client connect error: gRPC dial: context deadline exceeded: connection error: desc = "transport: Error while dialing: dial tcp [::1]:8080: connect: connection refused"
2023/06/12 23:41:56 Target still not ready. Giving up!
2023/06/12 23:41:56 🟢 Warmup completed
2023/06/12 23:41:56 🛑 Warm up finished but no requests were sent 🙁
2023/06/12 23:41:56 Writing file: ready
2023/06/12 23:41:56 Wrote file: ready


### :link: Related Issues