### PR TITLE
fix: fixes EOF error when having HTTP POST requests

### DIFF
--- a/internal/pkg/http/client_test.go
+++ b/internal/pkg/http/client_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"mittens/fixture"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,24 +39,21 @@ func TestMain(m *testing.M) {
 func TestRequestSuccessHTTP1(t *testing.T) {
 	c := NewClient(serverUrl, false, 10000, HTTP1)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", WorkingPath, make(map[string]string), reader)
+	resp := c.SendRequest("GET", WorkingPath, make(map[string]string), &reqBody)
 	assert.Nil(t, resp.Err)
 }
 
 func TestRequestSuccessH2C(t *testing.T) {
 	c := NewClient(serverUrl, false, 10000, H2C)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", WorkingPath, make(map[string]string), reader)
+	resp := c.SendRequest("GET", WorkingPath, make(map[string]string), &reqBody)
 	assert.Nil(t, resp.Err)
 }
 
 func TestHttpErrorHTTP1(t *testing.T) {
 	c := NewClient(serverUrl, false, 10000, HTTP1)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", "/", make(map[string]string), reader)
+	resp := c.SendRequest("GET", "/", make(map[string]string), &reqBody)
 	assert.Nil(t, resp.Err)
 	assert.Equal(t, resp.StatusCode, 404)
 }
@@ -65,8 +61,7 @@ func TestHttpErrorHTTP1(t *testing.T) {
 func TestHttpErrorH2C(t *testing.T) {
 	c := NewClient(serverUrl, false, 10000, H2C)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", "/", make(map[string]string), reader)
+	resp := c.SendRequest("GET", "/", make(map[string]string), &reqBody)
 	assert.Nil(t, resp.Err)
 	assert.Equal(t, resp.StatusCode, 404)
 }
@@ -74,16 +69,14 @@ func TestHttpErrorH2C(t *testing.T) {
 func TestConnectionErrorHTTP1(t *testing.T) {
 	c := NewClient("http://localhost:9999", false, 10000, HTTP1)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", "/potato", make(map[string]string), reader)
+	resp := c.SendRequest("GET", "/potato", make(map[string]string), &reqBody)
 	assert.NotNil(t, resp.Err)
 }
 
 func TestConnectionErrorH2C(t *testing.T) {
 	c := NewClient("http://localhost:9999", false, 10000, H2C)
 	reqBody := ""
-	reader := strings.NewReader(reqBody)
-	resp := c.SendRequest("GET", "/potato", make(map[string]string), reader)
+	resp := c.SendRequest("GET", "/potato", make(map[string]string), &reqBody)
 	assert.NotNil(t, resp.Err)
 }
 


### PR DESCRIPTION
Mittens requests are recycled within the requests channel. Once the body i/o reader was closed, succeeding requests were not successful.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

Currently mittens is broken due to an bug introduced in v1.46. During the processing of requests an i/o reader is passed to the client which leads to EOF errors on server side when the same request body is read the 2nd time. Hence only the first request of a warm-up succeeds and all others fail.  This should only affect configurations using POST data, but this needs to be fixed.

### :link: Related Issues