### PR TITLE
Fix: Grpc timeout not set for warmup requests (#354)

### DIFF
--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -128,7 +128,8 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 		return response.Response{Duration: time.Duration(0), Err: errors.New("no connection available"), Type: respType}
 	}
 
-	err = grpcurl.InvokeRPC(context.Background(), c.descriptorSource, c.conn, serviceMethod, interpolatedHeaders, loggingEventHandler, requestParser.Next)
+	ctx, _ := context.WithTimeout(context.Background(), time.Duration(c.timeoutMilliseconds)*time.Millisecond)
+	err = grpcurl.InvokeRPC(ctx, c.descriptorSource, c.conn, serviceMethod, interpolatedHeaders, loggingEventHandler, requestParser.Next)
 	endTime := time.Now()
 	if err != nil {
 		log.Printf("grpc response error: %s", err)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

This PR fixes bug https://github.com/ExpediaGroup/mittens/issues/354

Regression tested manually against a grpc server.

### :link: Related Issues

https://github.com/ExpediaGroup/mittens/issues/354