### PR TITLE
feat: add configurable log level, format, and datetime output (#309)

### DIFF
--- a/cmd/flags/grpc.go
+++ b/cmd/flags/grpc.go
@@ -17,7 +17,7 @@ package flags
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"mittens/internal/pkg/grpc"
 )
 
@@ -35,7 +35,7 @@ func (g *Grpc) initFlags() {
 }
 
 func (g *Grpc) getWarmupGrpcRequests() ([]grpc.Request, error) {
-	log.Print(g.Requests)
+	slog.Debug("gRPC requests", "requests", g.Requests)
 	return toGrpcRequests(g.Requests)
 }
 

--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -32,6 +32,9 @@ type Root struct {
 	ConcurrencyTargetSeconds int
 	ExitAfterWarmup          bool
 	FailReadiness            bool
+	LogLevel                 string
+	LogFormat                string
+	LogDateTimeFormat        string
 	FileProbe
 	Target
 	HTTP
@@ -54,6 +57,9 @@ func (r *Root) InitFlags() {
 	flag.IntVar(&r.ConcurrencyTargetSeconds, "concurrency-target-seconds", 0, "Time taken to reach expected concurrency. This is useful to ramp up traffic.")
 	flag.BoolVar(&r.ExitAfterWarmup, "exit-after-warmup", false, "If warm up process should finish after completion. This is useful to prevent container restarts.")
 	flag.BoolVar(&r.FailReadiness, "fail-readiness", false, "If set to true readiness will fail if no requests were sent.")
+	flag.StringVar(&r.LogLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	flag.StringVar(&r.LogFormat, "log-format", "text", "Log format: text, json")
+	flag.StringVar(&r.LogDateTimeFormat, "log-datetime-format", "iso8601", "Log datetime format: iso8601, rfc3339, rfc3339nano, epoch")
 
 	r.FileProbe.initFlags()
 	r.Target.initFlags()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,9 @@ package cmd
 
 import (
 	"flag"
-	"log"
+	"log/slog"
 	"mittens/cmd/flags"
+	"mittens/internal/pkg/logging"
 	"mittens/internal/pkg/probe"
 	"mittens/internal/pkg/safe"
 	"mittens/internal/pkg/warmup"
@@ -33,6 +34,10 @@ func CreateConfig() {
 	opts = &flags.Root{}
 	opts.InitFlags()
 	flag.Parse()
+
+	if err := logging.Setup(opts.LogLevel, opts.LogFormat, opts.LogDateTimeFormat); err != nil {
+		slog.Error("Failed to configure logging, using defaults", "error", err)
+	}
 }
 
 // RunCmdRoot runs the main logic
@@ -53,17 +58,17 @@ func run() int {
 	var validationError bool
 	httpRequests, err := opts.GetWarmupHTTPRequests()
 	if err != nil {
-		log.Printf("invalid HTTP options: %v", err)
+		slog.Error("Invalid HTTP options", "error", err)
 		validationError = true
 	}
 	grpcRequests, err := opts.GetWarmupGrpcRequests()
 	if err != nil {
-		log.Printf("invalid grpc options: %v", err)
+		slog.Error("Invalid gRPC options", "error", err)
 		validationError = true
 	}
 	targetOptions, err := opts.GetWarmupTargetOptions()
 	if err != nil {
-		log.Printf("invalid target options: %v", err)
+		slog.Error("Invalid target options", "error", err)
 		validationError = true
 	}
 
@@ -95,14 +100,14 @@ func run() int {
 			if err := target.WaitForReadinessProbe(maxReadinessWaitDurationInSeconds, opts.GetWarmupHTTPHeaders()); err == nil {
 				elapsed := time.Since(start).Seconds()
 
-				log.Printf("💚 Target took %d second(s) to become ready", int(elapsed))
+				slog.Info("Target is ready", "elapsed_seconds", int(elapsed))
 
 				globalMaxDurationSecondsLeft := opts.MaxDurationSeconds - int(elapsed)
 
 				maxDurationInSeconds := Min(globalMaxDurationSecondsLeft, opts.MaxWarmupDurationSeconds)
 
 				if maxDurationInSeconds < opts.MaxWarmupDurationSeconds {
-					log.Printf("⚠️ Warmup requests will only run for %d seconds instead of the configured %d seconds as to meet the global maximum duration of %d seconds", maxDurationInSeconds, opts.MaxWarmupDurationSeconds, opts.MaxDurationSeconds)
+					slog.Warn("Warmup duration capped by global maximum", "actual_seconds", maxDurationInSeconds, "configured_seconds", opts.MaxWarmupDurationSeconds, "max_duration_seconds", opts.MaxDurationSeconds)
 				}
 
 				wp := warmup.Warmup{
@@ -117,14 +122,14 @@ func run() int {
 
 				wp.Run(hasHttpRequests, hasGrpcRequests, maxDurationInSeconds, &requestsSentCounter)
 			} else {
-				log.Print("Target still not ready. Giving up!")
+				slog.Error("Target still not ready. Giving up!")
 			}
 		}
 		c1 <- true
 	})
 
 	<-c1
-	log.Println("🟢 Warmup completed")
+	slog.Info("Warmup completed")
 	return requestsSentCounter
 }
 
@@ -147,12 +152,12 @@ func block() {
 // The latter only happens if mittens did not send any requests and the user allows the readiness to fail.
 func postProcess(requestsSentCounter int) {
 	if opts.FailReadiness && requestsSentCounter == 0 {
-		log.Print("🛑 Warmup did not run. Mittens readiness probe will fail 🙁")
+		slog.Error("Warmup did not run. Mittens readiness probe will fail")
 	} else {
 		if requestsSentCounter == 0 {
-			log.Print("🛑 Warm up finished but no requests were sent 🙁")
+			slog.Warn("Warmup finished but no requests were sent")
 		} else {
-			log.Printf("Warm up finished 😊 Approximately %d reqs were sent", requestsSentCounter)
+			slog.Info("Warmup finished", "requests_sent", requestsSentCounter)
 		}
 
 		if opts.FileProbe.Enabled {

--- a/internal/pkg/grpc/client.go
+++ b/internal/pkg/grpc/client.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"mittens/internal/pkg/placeholders"
 	"mittens/internal/pkg/response"
 	"os"
@@ -66,10 +66,10 @@ func (c *Client) Connect(headers []string) error {
 	// Added to provide more information if a connection error occurs
 	dialOptions := []grpc.DialOption{grpc.WithBlock(), grpc.WithReturnConnectionError()}
 	if c.insecure {
-		log.Print("ignoring gRPC server SSL/TLS authentication")
+		slog.Info("Ignoring gRPC server SSL/TLS authentication")
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
-		log.Print("using gRPC server SSL/TLS authentication")
+		slog.Info("Using gRPC server SSL/TLS authentication")
 		tlsConf, err := grpcurl.ClientTLSConfig(c.insecure, "", "", "")
 		if err != nil {
 			return fmt.Errorf("failed to create TLS config: %v", err)
@@ -87,7 +87,7 @@ func (c *Client) Connect(headers []string) error {
 	reflectionClient := grpcreflect.NewClientAuto(contextWithMetadata, conn)
 	descriptorSource := grpcurl.DescriptorSourceFromServer(contextWithMetadata, reflectionClient)
 
-	log.Print("gRPC client connected")
+	slog.Info("gRPC client connected")
 	c.conn = conn
 	c.connClose = func() error { cancel(); return conn.Close() }
 	c.descriptorSource = descriptorSource
@@ -103,7 +103,7 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 	// TODO - create generic parser and formatter for any request, can we use text parser/formatter?
 	requestParser, formatter, err := grpcurl.RequestParserAndFormatter("json", c.descriptorSource, in, grpcurl.FormatOptions{})
 	if err != nil {
-		log.Printf("Cannot construct request parser and formatter for json")
+		slog.Error("Cannot construct request parser and formatter for json")
 		// FIXME FATAL
 		return response.Response{Duration: time.Duration(0), Err: err, Type: respType}
 	}
@@ -123,7 +123,7 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 	}
 
 	if c.conn == nil {
-		log.Printf("No connection available. Skip making request.")
+		slog.Warn("No connection available. Skip making request.")
 		return response.Response{Duration: time.Duration(0), Err: errors.New("no connection available"), Type: respType}
 	}
 
@@ -131,7 +131,7 @@ func (c *Client) SendRequest(serviceMethod string, message string, headers []str
 	err = grpcurl.InvokeRPC(ctx, c.descriptorSource, c.conn, serviceMethod, interpolatedHeaders, loggingEventHandler, requestParser.Next)
 	endTime := time.Now()
 	if err != nil {
-		log.Printf("grpc response error: %s", err)
+		slog.Error("gRPC response error", "error", err)
 		return response.Response{Duration: endTime.Sub(startTime), Err: nil, Type: respType}
 	}
 	return response.Response{Duration: endTime.Sub(startTime), Err: nil, Type: respType}
@@ -146,6 +146,6 @@ func (h eventHandler) OnReceiveResponse(msg proto.Message) {
 
 // Close calling close on a client that has not established connection does not return an error.
 func (c Client) Close() error {
-	log.Print("Closing gRPC client connection")
+	slog.Debug("Closing gRPC client connection")
 	return c.connClose()
 }

--- a/internal/pkg/http/client.go
+++ b/internal/pkg/http/client.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	"log/slog"
 	"mittens/internal/pkg/placeholders"
 	"mittens/internal/pkg/response"
 	"net"
@@ -84,7 +84,7 @@ func (c Client) SendRequest(method, path string, headers map[string]string, requ
 	url := fmt.Sprintf("%s/%s", c.host, strings.TrimLeft(path, "/"))
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		log.Printf("Failed to create request: %s %s: %v", method, url, err)
+		slog.Error("Failed to create request", "method", method, "url", url, "error", err)
 		return response.Response{Duration: time.Duration(0), Err: err, Type: respType}
 	}
 	if req.Body != nil {

--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -1,0 +1,93 @@
+//Copyright 2019 Expedia, Inc.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+)
+
+// Setup initializes the global slog logger based on the provided configuration.
+func Setup(level string, format string, timeFormat string) error {
+	lvl, err := parseLevel(level)
+	if err != nil {
+		return err
+	}
+
+	replacer := buildTimeReplacer(timeFormat)
+
+	opts := &slog.HandlerOptions{
+		Level:       lvl,
+		ReplaceAttr: replacer,
+	}
+
+	var handler slog.Handler
+	switch strings.ToLower(format) {
+	case "json":
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	case "text":
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	default:
+		return fmt.Errorf("unsupported log format %q, use text or json", format)
+	}
+
+	slog.SetDefault(slog.New(handler))
+	return nil
+}
+
+func parseLevel(level string) (slog.Level, error) {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unsupported log level %q, use debug, info, warn, or error", level)
+	}
+}
+
+func buildTimeReplacer(timeFormat string) func(groups []string, a slog.Attr) slog.Attr {
+	var layout string
+	switch strings.ToLower(timeFormat) {
+	case "rfc3339":
+		layout = time.RFC3339
+	case "rfc3339nano":
+		layout = time.RFC3339Nano
+	case "epoch":
+		layout = "epoch"
+	default:
+		// iso8601 or any unrecognized value defaults to RFC3339 (ISO 8601 compatible)
+		layout = time.RFC3339
+	}
+
+	return func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == slog.TimeKey {
+			t := a.Value.Time()
+			if layout == "epoch" {
+				a.Value = slog.Float64Value(float64(t.UnixMilli()) / 1000.0)
+			} else {
+				a.Value = slog.StringValue(t.Format(layout))
+			}
+		}
+		return a
+	}
+}

--- a/internal/pkg/logging/logging_test.go
+++ b/internal/pkg/logging/logging_test.go
@@ -1,0 +1,57 @@
+//Copyright 2019 Expedia, Inc.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetup_TextFormat(t *testing.T) {
+	err := Setup("info", "text", "iso8601")
+	assert.NoError(t, err)
+}
+
+func TestSetup_JsonFormat(t *testing.T) {
+	err := Setup("info", "json", "iso8601")
+	assert.NoError(t, err)
+}
+
+func TestSetup_AllLogLevels(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "warning", "error"} {
+		err := Setup(level, "text", "iso8601")
+		assert.NoError(t, err, "level %s should be valid", level)
+	}
+}
+
+func TestSetup_InvalidLogLevel(t *testing.T) {
+	err := Setup("invalid", "text", "iso8601")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported log level")
+}
+
+func TestSetup_InvalidLogFormat(t *testing.T) {
+	err := Setup("info", "xml", "iso8601")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported log format")
+}
+
+func TestSetup_AllDateTimeFormats(t *testing.T) {
+	for _, format := range []string{"iso8601", "rfc3339", "rfc3339nano", "epoch"} {
+		err := Setup("info", "text", format)
+		assert.NoError(t, err, "datetime format %s should be valid", format)
+	}
+}

--- a/internal/pkg/probe/file.go
+++ b/internal/pkg/probe/file.go
@@ -17,29 +17,28 @@
 package probe
 
 import (
-	"io/ioutil"
-	"log"
+	"log/slog"
 	"os"
 )
 
 // WriteFile writes sample content to a file. This file can be used as a liveness/readiness check e.g. in Kubernetes.
 func WriteFile(file string) {
-	log.Printf("Writing file: %s", file)
+	slog.Debug("Writing file", "path", file)
 
 	fileBytes := []byte("foo bar")
 
-	if err := ioutil.WriteFile(file, fileBytes, 0644); err != nil {
-		log.Printf("Writing to file failed with error: %v", err)
+	if err := os.WriteFile(file, fileBytes, 0644); err != nil {
+		slog.Error("Writing to file failed", "path", file, "error", err)
 		return
 	}
-	log.Printf("Wrote file: %s", file)
+	slog.Debug("Wrote file", "path", file)
 }
 
 // DeleteFile removes the named file and logs an error in case of issues.
 func DeleteFile(path string) {
 	var err = os.Remove(path)
 	if err != nil {
-		log.Printf("File not deleted")
+		slog.Warn("File not deleted", "path", path, "error", err)
 	}
 }
 

--- a/internal/pkg/safe/utils.go
+++ b/internal/pkg/safe/utils.go
@@ -15,14 +15,14 @@
 package safe
 
 import (
-	"log"
+	"log/slog"
 )
 
 // Do wraps a function with recover logic to catch unexpected panics.
 func Do(f func()) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Println("Unexpected panic was caught:", err)
+			slog.Error("Unexpected panic was caught", "error", err)
 		}
 	}()
 	f()
@@ -33,7 +33,7 @@ func Do(f func()) {
 func DoAndReturn(f func() int, fallback int) (result int) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Println("Unexpected panic was caught:", err)
+			slog.Error("Unexpected panic was caught", "error", err)
 			result = fallback
 		}
 	}()

--- a/internal/pkg/warmup/warmup.go
+++ b/internal/pkg/warmup/warmup.go
@@ -15,7 +15,7 @@
 package warmup
 
 import (
-	"log"
+	"log/slog"
 	"maps"
 	"math/rand"
 	"mittens/internal/pkg/grpc"
@@ -99,7 +99,7 @@ func (w Warmup) Run(hasHttpRequests bool, hasGrpcRequests bool, maxDurationSecon
 	if hasHttpRequests {
 		for i := 1; i <= w.Concurrency; i++ {
 			waitForRampUp(rampUpInterval, i)
-			log.Printf("Spawning new go routine for HTTP requests")
+			slog.Debug("Spawning new goroutine for HTTP requests")
 			wg.Add(1)
 			go safe.Do(func() {
 				w.HTTPWarmupWorker(&wg, w.GetWarmupHTTPRequests(maxDurationSeconds), w.HttpHeaders, w.RequestDelayMilliseconds, requestsSentCounter)
@@ -109,15 +109,15 @@ func (w Warmup) Run(hasHttpRequests bool, hasGrpcRequests bool, maxDurationSecon
 
 	if hasGrpcRequests {
 		// connect to gRPC server once and only if there are gRPC requests
-		log.Print("gRPC client connecting...")
+		slog.Info("gRPC client connecting")
 		connErr := w.Target.grpcClient.Connect(w.HttpHeaders)
 
 		if connErr != nil {
-			log.Printf("gRPC client connect error: %v", connErr)
+			slog.Error("gRPC client connect error", "error", connErr)
 		} else {
 			for i := 1; i <= w.Concurrency; i++ {
 				waitForRampUp(rampUpInterval, i)
-				log.Printf("Spawning new go routine for gRPC requests")
+				slog.Debug("Spawning new goroutine for gRPC requests")
 				wg.Add(1)
 				go safe.Do(func() {
 					w.GrpcWarmupWorker(&wg, w.GetWarmupGrpcRequests(maxDurationSeconds), w.HttpHeaders, w.RequestDelayMilliseconds, requestsSentCounter)
@@ -141,14 +141,14 @@ func (w Warmup) HTTPWarmupWorker(wg *sync.WaitGroup, requests <-chan http.Reques
 		resp := w.Target.httpClient.SendRequest(request.Method, request.Path, headersMap, request.Body)
 
 		if resp.Err != nil {
-			log.Printf("🔴 Error in request for %s: %v", request.Path, resp.Err)
+			slog.Error("HTTP request failed", "path", request.Path, "error", resp.Err)
 		} else {
 			*requestsSentCounter++
 
 			if resp.StatusCode/100 == 2 {
-				log.Printf("🟢 %s response\t%d ms\t%v\t%s\t%s", resp.Type, resp.Duration/time.Millisecond, resp.StatusCode, request.Method, request.Path)
+				slog.Info("HTTP response", "type", resp.Type, "duration_ms", int64(resp.Duration/time.Millisecond), "status", resp.StatusCode, "method", request.Method, "path", request.Path)
 			} else {
-				log.Printf("🔴 %s response\t%d ms\t%v\t%s\t%s", resp.Type, resp.Duration/time.Millisecond, resp.StatusCode, request.Method, request.Path)
+				slog.Warn("HTTP response", "type", resp.Type, "duration_ms", int64(resp.Duration/time.Millisecond), "status", resp.StatusCode, "method", request.Method, "path", request.Path)
 			}
 		}
 	}
@@ -163,10 +163,10 @@ func (w Warmup) GrpcWarmupWorker(wg *sync.WaitGroup, requests <-chan grpc.Reques
 		resp := w.Target.grpcClient.SendRequest(request.ServiceMethod, request.Message, headers, false)
 
 		if resp.Err != nil {
-			log.Printf("🔴 Error in request for %s: %v", request.ServiceMethod, resp.Err)
+			slog.Error("gRPC request failed", "service_method", request.ServiceMethod, "error", resp.Err)
 		} else {
 			*requestsSentCounter++
-			log.Printf("🟢 %s response\t%d ms %s", resp.Type, resp.Duration/time.Millisecond, request.ServiceMethod)
+			slog.Info("gRPC response", "type", resp.Type, "duration_ms", int64(resp.Duration/time.Millisecond), "service_method", request.ServiceMethod)
 		}
 
 	}


### PR DESCRIPTION
Add three new CLI flags for log output configuration:
- --log-level (debug, info, warn, error) default: info
- --log-format (text, json) default: text
- --log-datetime-format (iso8601, rfc3339, rfc3339nano, epoch) default: iso8601

Migrate from Go standard `log` package to `log/slog` for structured logging with level support. No external dependencies added.

Closes #309

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
  https://github.com/ExpediaGroup/mittens#how-to-build-and-run
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/mittens/blob/main/CONTRIBUTING.md
-->

### :pencil: Description


### :link: Related Issues