### PR TITLE
Fix keep-alive deadlock: wait for a signal instead of bare select {}

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ import (
 	"mittens/internal/pkg/safe"
 	"mittens/internal/pkg/warmup"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 )
 
@@ -135,11 +137,29 @@ func Min(x, y int) int {
 	return x
 }
 
-// block blocks forever unless `-exit-after-warmup` is set to true
+// block keeps the process alive after warm-up—so the container stays up and
+// its probe files remain—until the orchestrator asks it to stop. It returns
+// immediately when `-exit-after-warmup` is set.
+//
+// It waits for SIGINT/SIGTERM rather than parking on a bare `select {}`. Once
+// warm-up finishes every other goroutine has wound down, so an empty select
+// would be the only goroutine left and Go's runtime aborts the process with
+// "all goroutines are asleep - deadlock!" the moment it goes idle (see #366).
+// A blocked signal receive is wakeable, so the deadlock detector never fires,
+// and it lets the process exit gracefully when the signal arrives.
 func block() {
-	if !opts.ExitAfterWarmup {
-		select {}
+	if opts.ExitAfterWarmup {
+		return
 	}
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	blockUntilSignal(sig)
+}
+
+// blockUntilSignal blocks until a signal is received. It is kept separate from
+// block so the waiting behaviour can be tested without sending real signals.
+func blockUntilSignal(sig <-chan os.Signal) {
+	<-sig
 }
 
 // postProcess includes steps that run once the warmup finishes.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,64 @@
+//Copyright 2019 Expedia, Inc.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package cmd
+
+import (
+	"mittens/cmd/flags"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestBlockReturnsWhenExitAfterWarmup verifies that block() is a no-op when
+// -exit-after-warmup is set, so the process can exit right after warm-up.
+func TestBlockReturnsWhenExitAfterWarmup(t *testing.T) {
+	opts = &flags.Root{}
+	opts.ExitAfterWarmup = true
+
+	done := make(chan struct{})
+	go func() {
+		block()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("block did not return with -exit-after-warmup set")
+	}
+}
+
+// TestBlockUntilSignalUnblocksOnSignal verifies the keep-alive wait is
+// wakeable: it returns once a termination signal is delivered. This guards
+// against regressing to a bare `select {}`, which is unwakeable and trips
+// Go's deadlock detector when the process goes idle (see #366).
+func TestBlockUntilSignalUnblocksOnSignal(t *testing.T) {
+	sig := make(chan os.Signal, 1)
+
+	done := make(chan struct{})
+	go func() {
+		blockUntilSignal(sig)
+		close(done)
+	}()
+
+	sig <- syscall.SIGTERM
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("blockUntilSignal did not return after receiving a signal")
+	}
+}


### PR DESCRIPTION
### :pencil: Description

When `-exit-after-warmup` is not set (the default), `block()` kept the process alive by parking the main goroutine on a bare `select {}`. This is not a run-forever primitive: after warm-up completes, every other goroutine winds down, leaving the empty select as the only remaining goroutine. Go's runtime then aborts the process with `fatal error: all goroutines are asleep - deadlock!` the moment it goes idle — crash-looping the container even though it has already written its probe files. This reproduces on recent Go toolchains and matches the stack trace in #366 (`cmd/root.go`, `block()`); older toolchains only lengthened the fuse.

This replaces the bare select with a wait on `SIGINT`/`SIGTERM`. A signal receive is externally wakeable, so the deadlock detector never fires, and the process now shuts down gracefully when the orchestrator sends a termination signal. The `-exit-after-warmup` behaviour is unchanged.

**Reproduce (before this change):** build with a recent Go toolchain and run so that no warm-up requests are sent, e.g.

```
CGO_ENABLED=0 go build -o mittens . && ./mittens -max-readiness-wait-seconds 1
```

→ `fatal error: all goroutines are asleep - deadlock!`. After this change the process stays up and exits cleanly on Ctrl-C / `SIGTERM`.

New unit tests cover the `-exit-after-warmup` short-circuit and that the keep-alive wait unblocks on a signal. `go vet ./...`, `go build`, and `go test ./...` all pass locally.

### :link: Related Issues

Fixes #366
